### PR TITLE
Handle non-Windows autostart

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -14,6 +14,9 @@ from config import APP_NAME, ORG_NAME, DEFAULT_PORT, ICON_PATH
 
 def set_autostart(enabled):
     """Be- vagy kikapcsolja az automatikus indulást a Windows Registry-ben."""
+    if not sys.platform.startswith("win"):
+        logging.info("Autostart beállítás kihagyva: nem Windows platform.")
+        return
     key_path = r"Software\Microsoft\Windows\CurrentVersion\Run"
     app_name = "KVM_Switch"
     try:


### PR DESCRIPTION
## Summary
- update `set_autostart` so it only touches the registry on Windows

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6855b28c2ffc832797f0ced0da85158a