### PR TITLE
Allow stopping the service via same button

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -185,7 +185,6 @@ class MainWindow(QMainWindow):
         self.host_code.setEnabled(enabled)
         self.client_code.setEnabled(enabled)
         self.autostart_check.setEnabled(enabled)
-        self.start_button.setEnabled(enabled)
     def on_status_update(self, message):
         self.status_label.setText(message)
         logging.info(f"GUI Status Update: {message}")


### PR DESCRIPTION
## Summary
- keep the Start/Stop button enabled after starting the service

## Testing
- `python3 -m py_compile main.py gui.py worker.py config.py kvm_gui_v2_backend.py build_exe.py`

------
https://chatgpt.com/codex/tasks/task_e_6855b75e17308327bf66d9e61a3d03f5