### PR TITLE
Enable multiple clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,6 @@ application logs activity to `kvm_switch.log` and stores settings via
 `QSettings`. Use the interface to configure host and client codes, select the
 operating mode (host or client) and start or stop the KVM service.
 
+The host server now accepts multiple client connections simultaneously. All
+connected receivers will get the forwarded input events.
+


### PR DESCRIPTION
## Summary
- allow several clients to connect to the server
- broadcast input events to all connected clients
- document that the host now supports multiple receivers

## Testing
- `python -m py_compile worker.py`
- `python -m py_compile *.py`
- `git ls-files '*.py' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6855baa5abec83278c1ad5da58e1d69b