### PR TITLE
Fix build script exe naming and icon

### DIFF
--- a/build_linux.bat
+++ b/build_linux.bat
@@ -5,6 +5,6 @@ REM Requires WSL with Python installed. PyInstaller will be installed if missing
 setlocal
 set PROJ_DIR=%~dp0
 
-wsl bash -ic "cd $(wslpath '%PROJ_DIR%') && python3 -m pip install --user pyinstaller && python3 -m PyInstaller --onefile main.py"
+wsl bash -ic "cd $(wslpath '%PROJ_DIR%') && python3 -m pip install --user pyinstaller && python3 -m PyInstaller --onefile --name Szamitepvalto-Extravaganza --icon keyboard_mouse_switch_icon.ico main.py"
 
 endlocal


### PR DESCRIPTION
## Summary
- fix build script output name and add icon to resulting executable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855fc68fe648327b8f90538f3516ed1