### PR TITLE
Fix winreg usage for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,9 @@ When controlling the laptop, press **Ctrl + Shift + F12** to immediately switch
 control to the EliteDesk. The laptop client sends a command back to the host,
 which activates the EliteDesk as the new target.
 
+### Autostart
+
+On Windows the application configures autostart via the registry. On Linux a
+``.desktop`` entry is created under ``~/.config/autostart``. Disable the option
+in the GUI to remove the entry.
+


### PR DESCRIPTION
## Summary
- import `winreg` only on Windows
- create Linux autostart entry in `~/.config/autostart`
- update autostart checkbox label and README with platform details

## Testing
- `python3 -m py_compile build_exe.py config.py gui.py kvm_gui_v2_backend.py main.py worker.py`

------
https://chatgpt.com/codex/tasks/task_e_68560a0d9b988327ab2cfef19abd2697