### PR TITLE
Fix build script naming and icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ python build_exe.py
 ```
 
 The script ensures PyInstaller is installed and bundles `main.py` into a single
-`exe` without showing a console window on startup.
+`exe` named `Szamitepvalto-Extravaganza.exe` with the icon from
+`keyboard_mouse_switch_icon.ico`. The console window is hidden on startup.
 
 ## Building a Linux executable
 

--- a/build_exe.py
+++ b/build_exe.py
@@ -23,6 +23,10 @@ def build():
         "PyInstaller",
         "--onefile",
         "--windowed",  # hide console window
+        "--name",
+        "Szamitepvalto-Extravaganza",
+        "--icon",
+        "keyboard_mouse_switch_icon.ico",
         "main.py",
     ]
     subprocess.check_call(cmd)


### PR DESCRIPTION
## Summary
- pass executable name and icon to `PyInstaller`
- document exe name and icon in README

## Testing
- `python build_exe.py`

------
https://chatgpt.com/codex/tasks/task_e_685685cdd9408327bf9fe7024c1dccdb