### PR TITLE
Ensure icon loads in packaged executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ python build_exe.py
 ```
 
 The script ensures PyInstaller is installed and bundles `main.py` into a single
-`exe` named `Szamitepvalto-Extravaganza.exe` with the icon from
-`keyboard_mouse_switch_icon.ico`. The console window is hidden on startup.
+`exe` named `Szamitepvalto-Extravaganza.exe`. The icon from
+`keyboard_mouse_switch_icon.ico` is included using the `--add-data` option so it
+is available at runtime. The console window is hidden on startup.
 
 ## Building a Linux executable
 

--- a/build_exe.py
+++ b/build_exe.py
@@ -27,6 +27,8 @@ def build():
         "Szamitepvalto-Extravaganza",
         "--icon",
         "keyboard_mouse_switch_icon.ico",
+        "--add-data",
+        "keyboard_mouse_switch_icon.ico;.",
         "main.py",
     ]
     subprocess.check_call(cmd)

--- a/config.py
+++ b/config.py
@@ -1,6 +1,9 @@
 # config.py
 # Központi konfigurációs értékek és konstansok
 
+import os
+import sys
+
 # Alkalmazás adatai a QSettings-hez
 APP_NAME = "KVMApp"
 ORG_NAME = "MyKVM"
@@ -17,5 +20,12 @@ VK_NUMPAD0 = 96
 VK_NUMPAD1 = 97
 VK_F12 = 123
 
+
+def resource_path(relative_path: str) -> str:
+    """Return absolute path to resource, compatible with PyInstaller."""
+    base_path = getattr(sys, "_MEIPASS", os.path.dirname(os.path.abspath(__file__)))
+    return os.path.join(base_path, relative_path)
+
+
 # Program icon path
-ICON_PATH = "keyboard_mouse_switch_icon.ico"
+ICON_PATH = resource_path("keyboard_mouse_switch_icon.ico")


### PR DESCRIPTION
## Summary
- include the icon file for PyInstaller builds
- resolve the icon path at runtime to handle the frozen executable
- document the `--add-data` option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_6856a5110c688327bda2cc512e61a12e