### PR TITLE
Handle autostart logging path

### DIFF
--- a/kvm_gui_v2_backend.py
+++ b/kvm_gui_v2_backend.py
@@ -7,6 +7,7 @@ import time
 import socket
 import json
 import threading
+import os
 import logging
 from pynput import mouse, keyboard
 from zeroconf import ServiceInfo, Zeroconf, ServiceBrowser
@@ -18,11 +19,14 @@ from PySide6.QtCore import QSize, QSettings, QThread, QObject, Signal
 from config import ICON_PATH
 
 # --- NAPLÓZÁS BEÁLLÍTÁSA ---
+log_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+log_file = os.path.join(log_dir, "kvm_switch.log")
+
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(levelname)s - %(threadName)s - %(message)s',
     handlers=[
-        logging.FileHandler("kvm_switch.log"), # Naplózás fájlba
+        logging.FileHandler(log_file),  # Naplózás fájlba
         logging.StreamHandler(sys.stdout)     # Naplózás a konzolra is
     ]
 )

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 # A program fő belépési pontja.
 
 import sys
+import os
 import logging
 from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QIcon
@@ -9,11 +10,14 @@ from gui import MainWindow
 from config import ICON_PATH
 
 # A naplózást itt, a legfelső szinten állítjuk be.
+log_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+log_file = os.path.join(log_dir, "kvm_switch.log")
+
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(levelname)s - %(threadName)s - %(message)s',
     handlers=[
-        logging.FileHandler("kvm_switch.log", mode='w'),
+        logging.FileHandler(log_file, mode='w'),
         logging.StreamHandler(sys.stdout)
     ]
 )


### PR DESCRIPTION
## Summary
- log to a file in the executable's directory
- apply the same logic to the legacy backend

## Testing
- `python -m py_compile main.py kvm_gui_v2_backend.py worker.py gui.py build_exe.py`

------
https://chatgpt.com/codex/tasks/task_e_6856a94f8b6c83278a354616f6adf120