### PR TITLE
Add tray-only startup mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ which activates the EliteDesk as the new target.
 ### Autostart
 
 On Windows the application configures autostart via the registry. On Linux a
-``.desktop`` entry is created under ``~/.config/autostart``. Disable the option
-in the GUI to remove the entry.
+``.desktop`` entry is created under ``~/.config/autostart``. When started this
+way the program is launched with the ``--tray`` argument so it remains hidden in
+the system tray. Disable the option in the GUI to remove the entry.
 

--- a/gui.py
+++ b/gui.py
@@ -4,6 +4,7 @@
 import sys
 import time
 import logging
+import os
 
 # Windows specific module only available on that platform
 if sys.platform.startswith("win"):
@@ -41,7 +42,8 @@ def set_autostart(enabled: bool) -> None:
         try:
             reg_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_path, 0, winreg.KEY_WRITE)
             if enabled:
-                app_path = f'"{sys.executable}" "{__file__}"'
+                script = os.path.join(os.path.dirname(__file__), "main.py")
+                app_path = f'"{sys.executable}" "{script}" --tray'
                 winreg.SetValueEx(reg_key, app_name, 0, winreg.REG_SZ, app_path)
                 logging.info("Automatikus indulás bekapcsolva. Útvonal: %s", app_path)
             else:
@@ -53,14 +55,14 @@ def set_autostart(enabled: bool) -> None:
         except Exception as e:  # pragma: no cover - platform specific
             logging.error("Hiba az automatikus indulás beállításakor: %s", e)
     elif sys.platform.startswith("linux"):
-        import os
 
         autostart_dir = os.path.join(os.path.expanduser("~"), ".config", "autostart")
         os.makedirs(autostart_dir, exist_ok=True)
         desktop_file = os.path.join(autostart_dir, "KVM_Switch.desktop")
 
         if enabled:
-            exec_cmd = f"{sys.executable} {os.path.abspath(__file__)}"
+            script = os.path.join(os.path.dirname(__file__), "main.py")
+            exec_cmd = f"{sys.executable} {script} --tray"
             desktop_contents = (
                 "[Desktop Entry]\n"
                 "Type=Application\n"

--- a/main.py
+++ b/main.py
@@ -36,10 +36,14 @@ if __name__ == "__main__":
         logging.error("A program már fut. Csak egy példány indítható.")
         sys.exit(1)
 
+    start_hidden = "--tray" in sys.argv or "--minimized" in sys.argv
     app = QApplication(sys.argv)
     # Prevent the application from quitting when the last window is closed.
     app.setQuitOnLastWindowClosed(False)
     app.setWindowIcon(QIcon(ICON_PATH))
     window = MainWindow()
-    window.show()
+    if start_hidden:
+        window.hide()
+    else:
+        window.show()
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- add `--tray` flag so the app can start hidden
- include the flag in autostart entries for Windows and Linux
- document autostart starting in tray

## Testing
- `python -m py_compile *.py`
- `pip install -r requirements.txt` *(fails: ImportError: libEGL.so.1 not found when running main.py)*

------
https://chatgpt.com/codex/tasks/task_e_6856ac1bdf6083278770ca30fb5fc41f