### PR TITLE
Enable tray mode autostart for exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,5 +86,7 @@ which activates the EliteDesk as the new target.
 On Windows the application configures autostart via the registry. On Linux a
 ``.desktop`` entry is created under ``~/.config/autostart``. When started this
 way the program is launched with the ``--tray`` argument so it remains hidden in
-the system tray. Disable the option in the GUI to remove the entry.
+the system tray. If a packaged executable is used the stored path now points
+directly to the ``.exe`` with the same ``--tray`` flag. Disable the option in
+the GUI to remove the entry.
 

--- a/gui.py
+++ b/gui.py
@@ -42,8 +42,11 @@ def set_autostart(enabled: bool) -> None:
         try:
             reg_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_path, 0, winreg.KEY_WRITE)
             if enabled:
-                script = os.path.join(os.path.dirname(__file__), "main.py")
-                app_path = f'"{sys.executable}" "{script}" --tray'
+                if getattr(sys, "frozen", False):
+                    app_path = f'"{sys.executable}" --tray'
+                else:
+                    script = os.path.join(os.path.dirname(__file__), "main.py")
+                    app_path = f'"{sys.executable}" "{script}" --tray'
                 winreg.SetValueEx(reg_key, app_name, 0, winreg.REG_SZ, app_path)
                 logging.info("Automatikus indulás bekapcsolva. Útvonal: %s", app_path)
             else:
@@ -61,8 +64,11 @@ def set_autostart(enabled: bool) -> None:
         desktop_file = os.path.join(autostart_dir, "KVM_Switch.desktop")
 
         if enabled:
-            script = os.path.join(os.path.dirname(__file__), "main.py")
-            exec_cmd = f"{sys.executable} {script} --tray"
+            if getattr(sys, "frozen", False):
+                exec_cmd = f"{sys.executable} --tray"
+            else:
+                script = os.path.join(os.path.dirname(__file__), "main.py")
+                exec_cmd = f"{sys.executable} {script} --tray"
             desktop_contents = (
                 "[Desktop Entry]\n"
                 "Type=Application\n"


### PR DESCRIPTION
## Summary
- allow autostart to run the packaged executable with `--tray`
- document exe tray behaviour

## Testing
- `python -m py_compile *.py`
- `pip install -r requirements.txt` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6856add4428c83278790ca94283529e0