### PR TITLE
Enable automatic KVM activation on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ which activates the EliteDesk as the new target.
 
 On Windows the application configures autostart via the registry. On Linux a
 ``.desktop`` entry is created under ``~/.config/autostart``. When started this
-way the program is launched with the ``--tray`` argument so it remains hidden in
-the system tray. Disable the option in the GUI to remove the entry.
+way the program is launched with the ``--tray --auto`` arguments so it remains
+hidden in the system tray and immediately activates the KVM service using the
+saved settings. Disable the option in the GUI to remove the entry.
 

--- a/gui.py
+++ b/gui.py
@@ -43,7 +43,7 @@ def set_autostart(enabled: bool) -> None:
             reg_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_path, 0, winreg.KEY_WRITE)
             if enabled:
                 script = os.path.join(os.path.dirname(__file__), "main.py")
-                app_path = f'"{sys.executable}" "{script}" --tray'
+                app_path = f'"{sys.executable}" "{script}" --tray --auto'
                 winreg.SetValueEx(reg_key, app_name, 0, winreg.REG_SZ, app_path)
                 logging.info("Automatikus indulás bekapcsolva. Útvonal: %s", app_path)
             else:
@@ -62,7 +62,7 @@ def set_autostart(enabled: bool) -> None:
 
         if enabled:
             script = os.path.join(os.path.dirname(__file__), "main.py")
-            exec_cmd = f"{sys.executable} {script} --tray"
+            exec_cmd = f"{sys.executable} {script} --tray --auto"
             desktop_contents = (
                 "[Desktop Entry]\n"
                 "Type=Application\n"
@@ -86,8 +86,9 @@ def set_autostart(enabled: bool) -> None:
 
 class MainWindow(QMainWindow):
     # A MainWindow többi része változatlan...
-    def __init__(self):
+    def __init__(self, *, auto_start=False):
         super().__init__()
+        self._auto_start = auto_start
         self.setWindowTitle("KVM Switch Vezérlőpult v7")
         self.setWindowIcon(QIcon(ICON_PATH))
         # Prevent resizing during runtime
@@ -157,6 +158,8 @@ class MainWindow(QMainWindow):
         self.kvm_worker = None
         self.init_tray_icon()
         self.load_settings()
+        if self._auto_start:
+            self.start_kvm_service()
     def get_settings(self):
         if self.radio_desktop.isChecked():
             mode = 'ado'

--- a/main.py
+++ b/main.py
@@ -37,11 +37,13 @@ if __name__ == "__main__":
         sys.exit(1)
 
     start_hidden = "--tray" in sys.argv or "--minimized" in sys.argv
+    auto_start_service = "--auto" in sys.argv
+
     app = QApplication(sys.argv)
     # Prevent the application from quitting when the last window is closed.
     app.setQuitOnLastWindowClosed(False)
     app.setWindowIcon(QIcon(ICON_PATH))
-    window = MainWindow()
+    window = MainWindow(auto_start=auto_start_service)
     if start_hidden:
         window.hide()
     else:


### PR DESCRIPTION
## Summary
- add `--auto` CLI arg to start KVM service automatically
- start service if `--auto` is provided
- update autostart registry/desktop entry to include `--auto`
- document auto-start behaviour in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py gui.py worker.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ade788788327ac13223deeb653de