### PR TITLE
Enable auto connect on autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,5 +88,6 @@ On Windows the application configures autostart via the registry. On Linux a
 way the program is launched with the ``--tray`` argument so it remains hidden in
 the system tray. If a packaged executable is used the stored path now points
 directly to the ``.exe`` with the same ``--tray`` flag. Disable the option in
-the GUI to remove the entry.
+the GUI to remove the entry. When launched from autostart the application now
+automatically activates the previously selected connection.
 

--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     start_hidden = "--tray" in sys.argv or "--minimized" in sys.argv
+    auto_connect = "--tray" in sys.argv
     app = QApplication(sys.argv)
     # Prevent the application from quitting when the last window is closed.
     app.setQuitOnLastWindowClosed(False)
@@ -44,6 +45,8 @@ if __name__ == "__main__":
     window = MainWindow()
     if start_hidden:
         window.hide()
+        if auto_connect:
+            window.start_kvm_service()
     else:
         window.show()
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- auto-start the KVM service when launched with `--tray`
- document the automatic connection in README

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856af10392083278234ef173c1b0177