### PR TITLE
Optimize streaming loop delay

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -9,6 +9,9 @@ from monitorcontrol import get_monitors
 from PySide6.QtCore import QObject, Signal
 from config import SERVICE_TYPE, SERVICE_NAME_PREFIX, VK_CTRL, VK_CTRL_R, VK_NUMPAD0, VK_NUMPAD1, VK_F12
 
+# Delay between iterations in the streaming loop to lower CPU usage
+STREAM_LOOP_DELAY = 0.05
+
 class KVMWorker(QObject):
     finished = Signal()
     status_update = Signal(str)
@@ -433,7 +436,7 @@ class KVMWorker(QObject):
         k_listener.start()
         
         while self.kvm_active and self._running:
-            time.sleep(0.01)
+            time.sleep(STREAM_LOOP_DELAY)
 
         for ktype, kval in list(pressed_keys):
             send({"type": "key", "key_type": ktype, "key": kval, "pressed": False})


### PR DESCRIPTION
## Summary
- add a constant for streaming loop delay
- lower CPU usage by sleeping 50ms per iteration

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6856b04f3b04832795686466a61124a1