### PR TITLE
Add auto-retry for mouse streaming

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -275,8 +275,16 @@ class KVMWorker(QObject):
         self.kvm_active = True
         self.status_update.emit("Állapot: Aktív...")
         logging.info("KVM aktiválva.")
-        self.streaming_thread = threading.Thread(target=self.start_kvm_streaming, daemon=True, name="StreamingThread")
+        self.streaming_thread = threading.Thread(target=self._streaming_loop, daemon=True, name="StreamingThread")
         self.streaming_thread.start()
+
+    def _streaming_loop(self):
+        """Keep streaming active and restart if it stops unexpectedly."""
+        while self.kvm_active and self._running:
+            self.start_kvm_streaming()
+            if self.kvm_active and self._running:
+                logging.warning("Egér szinkronizáció megszakadt, újraindítás...")
+                time.sleep(1)
 
     def deactivate_kvm(self, switch_monitor=None):
         self.kvm_active = False


### PR DESCRIPTION
## Summary
- add `_streaming_loop` to restart mouse sync if the streaming thread stops
- start `_streaming_loop` instead of `start_kvm_streaming`

## Testing
- `python -m py_compile main.py gui.py kvm_gui_v2_backend.py worker.py config.py build_exe.py`


------
https://chatgpt.com/codex/tasks/task_e_6856c1fed40083278099de44cadb38cd