### PR TITLE
Improve hotkey detection

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -129,14 +129,14 @@ class KVMWorker(QObject):
         self.status_update.emit(f"Adó szolgáltatás regisztrálva. Gyorsbillentyű: Laptop - Ctrl + Numpad 0, ElitDesk - Ctrl + Numpad 1")
         logging.info("Zeroconf szolgáltatás regisztrálva.")
 
-        hotkey_laptop = {VK_CTRL, VK_NUMPAD0}
-        hotkey_laptop_r = {VK_CTRL_R, VK_NUMPAD0}
-        hotkey_elitdesk = {VK_CTRL, VK_NUMPAD1}
-        hotkey_elitdesk_r = {VK_CTRL_R, VK_NUMPAD1}
+        hotkey_laptop = {keyboard.Key.ctrl_l, keyboard.KeyCode.from_vk(VK_NUMPAD0)}
+        hotkey_laptop_r = {keyboard.Key.ctrl_r, keyboard.KeyCode.from_vk(VK_NUMPAD0)}
+        hotkey_elitdesk = {keyboard.Key.ctrl_l, keyboard.KeyCode.from_vk(VK_NUMPAD1)}
+        hotkey_elitdesk_r = {keyboard.Key.ctrl_r, keyboard.KeyCode.from_vk(VK_NUMPAD1)}
         current_pressed_ids = set()
 
         def get_id(key):
-            return key.vk if hasattr(key, 'vk') and key.vk is not None else key
+            return key
 
         def on_press(key):
             key_id = get_id(key)


### PR DESCRIPTION
## Summary
- detect hotkeys using `pynput` key objects instead of raw VK codes

## Testing
- `python -m py_compile worker.py gui.py main.py config.py kvm_gui_v2_backend.py`

------
https://chatgpt.com/codex/tasks/task_e_6856c6318010832791ab6653876c9575