### PR TITLE
Fix stuck hotkey state causing repeated KVM toggles

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -144,10 +144,12 @@ class KVMWorker(QObject):
             if hotkey_laptop.issubset(current_pressed_ids) or hotkey_laptop_r.issubset(current_pressed_ids):
                 logging.info("!!! Laptop gyorsbillentyű észlelve! Váltás... !!!")
                 self.toggle_client_control('laptop', switch_monitor=False)
+                current_pressed_ids.clear()
                 self.release_hotkey_keys()
             elif hotkey_elitdesk.issubset(current_pressed_ids) or hotkey_elitdesk_r.issubset(current_pressed_ids):
                 logging.info("!!! ElitDesk gyorsbillentyű észlelve! Váltás... !!!")
                 self.toggle_client_control('elitedesk', switch_monitor=True)
+                current_pressed_ids.clear()
                 self.release_hotkey_keys()
 
         def on_release(key):


### PR DESCRIPTION
## Summary
- avoid repeated activation when pressing the hotkey

## Testing
- `python -m py_compile main.py gui.py worker.py kvm_gui_v2_backend.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_6856cb03da3483278ac98cb95ed11bdb