### PR TITLE
Fix stuck modifier on KVM toggle

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -477,9 +477,24 @@ class KVMWorker(QObject):
 
                 if ((VK_CTRL in current_vks or VK_CTRL_R in current_vks) and VK_NUMPAD0 in current_vks):
                     self.toggle_kvm_active(False)
+                    # ensure hotkey keys are released on the client
+                    for vk_code in [VK_CTRL, VK_CTRL_R]:
+                        if vk_code in current_vks:
+                            send({"type": "key", "key_type": "vk", "key": vk_code, "pressed": False})
+                            pressed_keys.discard(("vk", vk_code))
+                    send({"type": "key", "key_type": "vk", "key": VK_NUMPAD0, "pressed": False})
+                    pressed_keys.discard(("vk", VK_NUMPAD0))
+                    current_vks.clear()
                     return
                 if ((VK_CTRL in current_vks or VK_CTRL_R in current_vks) and VK_NUMPAD1 in current_vks):
                     self.toggle_kvm_active(True)
+                    for vk_code in [VK_CTRL, VK_CTRL_R]:
+                        if vk_code in current_vks:
+                            send({"type": "key", "key_type": "vk", "key": vk_code, "pressed": False})
+                            pressed_keys.discard(("vk", vk_code))
+                    send({"type": "key", "key_type": "vk", "key": VK_NUMPAD1, "pressed": False})
+                    pressed_keys.discard(("vk", VK_NUMPAD1))
+                    current_vks.clear()
                     return
 
                 if hasattr(k, "char") and k.char is not None:


### PR DESCRIPTION
## Summary
- release Ctrl/Numpad hotkeys on remote when toggling

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856f561406c832786b5d7a365652ebe