### PR TITLE
Improve handling of slow clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ stop the KVM service. The correct operating mode is selected automatically.
 The desktop acting as the host now accepts multiple client connections simultaneously. All
 connected receivers will get the forwarded input events.
 
+Slow clients that cannot keep up with the stream are disconnected after a short
+send timeout so they no longer cause lag for others. Input events are queued up
+to a limited size and older ones are discarded if necessary. The application
+also attempts to run with high process priority for smoother forwarding.
+
 ### System tray
 
 When closing the main window with the **X** button the window is automatically

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@
 import sys
 import os
 import logging
+import ctypes
 from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QIcon
 from PySide6.QtCore import QLockFile, QStandardPaths, QSettings
@@ -23,8 +24,23 @@ logging.basicConfig(
     ]
 )
 
+
+def set_high_priority():
+    """Attempt to run the process with high priority."""
+    try:
+        if os.name == "nt":
+            HIGH_PRIORITY_CLASS = 0x0080
+            ctypes.windll.kernel32.SetPriorityClass(
+                ctypes.windll.kernel32.GetCurrentProcess(), HIGH_PRIORITY_CLASS
+            )
+        else:
+            os.nice(-10)
+    except Exception as e:
+        logging.warning("Failed to set high process priority: %s", e)
+
 if __name__ == "__main__":
     logging.info("Alkalmazás indítása...")
+    set_high_priority()
 
     # Allow only a single running instance using a lock file
     data_dir = QStandardPaths.writableLocation(QStandardPaths.AppDataLocation)


### PR DESCRIPTION
## Summary
- handle slow-reading clients by timing out sender sockets
- limit queued events and drop the oldest when full
- attempt to set high process priority at start
- document these improvements

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6857f322e8548327a1ed8347b5a015b0