### PR TITLE
Improve hotkey logging and client recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ send timeout so they no longer cause lag for others. Input events are queued up
 to a limited size and older ones are discarded if necessary. The application
 also attempts to run with high process priority for smoother forwarding.
 
+### Debug logging
+
+For troubleshooting, enable verbose debug logging by editing `main.py` and
+setting `logging.basicConfig(level=logging.DEBUG)`. The log file
+`kvm_switch.log` will then contain detailed information about hotkey detection,
+network activity and event forwarding.
+
 ### System tray
 
 When closing the main window with the **X** button the window is automatically


### PR DESCRIPTION
## Summary
- log `current_vks` when hotkeys fire
- warn if toggling KVM when no active client is selected
- after deactivation reselect a client if the current one disconnected
- document how to enable debug logging

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python main.py --help` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6857f7602b448327aee96182ae68daad