### PR TITLE
Handle pyperclip failures gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,9 @@ python clipboard_sync.py client <server-ip> --port 8765
 
 Whenever the clipboard changes on any connected computer the new contents are sent to all others.
 The script relies on the `pyperclip` library for cross-platform clipboard access.
+On Linux systems `pyperclip` requires an external clipboard tool such as
+`xclip`, `xsel` or `wl-clipboard` to be installed:
+
+```bash
+sudo apt-get install xclip  # or xsel/wl-clipboard
+```


### PR DESCRIPTION
## Summary
- wrap all `pyperclip.copy`/`paste` uses in try/except blocks
- log any clipboard access errors
- document Linux clipboard dependencies in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857f789d58483279ea3e5375f630f99