### PR TITLE
Fix stuck keys on disconnect

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -47,7 +47,7 @@ class KVMWorker(QObject):
         self.device_name = settings.get('device_name', socket.gethostname())
 
     def release_hotkey_keys(self):
-        """Release potential stuck hotkey keys."""
+        """Release potential stuck hotkey keys without generating input."""
         kc = keyboard.Controller()
         keys = [
             keyboard.Key.ctrl_l,
@@ -58,7 +58,6 @@ class KVMWorker(QObject):
         ]
         for k in keys:
             try:
-                kc.press(k)
                 kc.release(k)
             except Exception:
                 pass


### PR DESCRIPTION
## Summary
- prevent numpad keystrokes from being generated when the connection drops

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py worker.py` *(fails: E401 multiple imports on one line, E302 expected 2 blank lines, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685845fb88fc8327b178f80f4188bd11