### PR TITLE
Expand GUI height

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -74,7 +74,8 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("KVM Switch Vezérlőpult v7")
         self.setWindowIcon(QIcon(ICON_PATH))
         # Prevent resizing during runtime
-        self.setFixedSize(QSize(450, 400))
+        # Provide a bit more vertical room so texts are not cramped
+        self.setFixedSize(QSize(450, 480))
 
         central_widget = QWidget()
         self.setCentralWidget(central_widget)


### PR DESCRIPTION
## Summary
- give the main window more vertical room so text isn't cramped

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_685c0cea31548327a1e124b62902e8aa