### PR TITLE
Fix progress dialog reset

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -330,6 +330,7 @@ class MainWindow(QMainWindow):
         self.progress_dialog.setWindowTitle(title)
         self.progress_dialog.canceled.connect(self.cancel_transfer)
         self.progress_dialog.setAutoClose(False)
+        self.progress_dialog.setAutoReset(False)
         self.progress_dialog.setMinimumDuration(0)
         self.progress_dialog.setLabelText("Fájlinformációk lekérése...")
         self.progress_dialog.show()
@@ -379,7 +380,6 @@ class MainWindow(QMainWindow):
                 else:
                     label_text = f"{name}: {current_mb:.1f}MB / {total_mb:.1f}MB"
                 self.progress_dialog.setLabelText(label_text)
-
 
     def _close_progress_dialog_if_exists(self):
         if self.progress_dialog:


### PR DESCRIPTION
## Summary
- avoid QProgressDialog auto-reset between transfer phases

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_685c2fb469a08327b306b6114d104237