### PR TITLE
Improve paste progress feedback and logging

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -426,6 +426,29 @@ class MainWindow(QMainWindow):
             self.progress_dialog.setLabelText(label)
             return
 
+        elif operation == "extracting_archive":
+            logging.info("[GUI_DEBUG] update_progress for 'extracting_archive': Name=%s, Done=%d, Total=%d", name, done, total)
+            self.progress_dialog.setWindowTitle("Fájl feldolgozása")
+
+            if done == 0 and total == 1:
+                self.progress_dialog.setLabelText(f"Kibontás folyamatban: {name}...")
+                self.progress_dialog.setMaximum(total)
+                self.progress_dialog.setValue(done)
+            elif done >= total:
+                self.progress_dialog.setMaximum(total)
+                self.progress_dialog.setValue(total)
+                self.progress_dialog.setLabelText(f"{name}: Feldolgozás kész!")
+                logging.info("[GUI_DEBUG] 'extracting_archive' complete for %s. Starting 5s close timer.", name)
+                try:
+                    cancel_button = self.progress_dialog.findChild(QPushButton)
+                    if cancel_button and cancel_button.text().lower() == "mégse":
+                        cancel_button.setEnabled(False)
+                        cancel_button.setText("Kész")
+                except Exception as e:
+                    logging.warning("[GUI_DEBUG] Failed to update cancel button for extracting_archive: %s", e)
+                QTimer.singleShot(5000, self._close_progress_dialog_if_exists)
+            return
+
         if operation in ("sending_archive", "receiving_archive"):
             desired_title = (
                 "Fájl küldése" if operation == "sending_archive" else "Fájl fogadása"

--- a/worker.py
+++ b/worker.py
@@ -622,10 +622,16 @@ class KVMWorker(QObject):
                 logging.warning('No shared files to paste')
                 return
             try:
+                archive_name = os.path.basename(self.network_file_clipboard['archive']) if self.network_file_clipboard and self.network_file_clipboard.get('archive') else "archívum"
+                logging.info("[WORKER_DEBUG] Starting server-side paste (extraction) for: %s", archive_name)
+                self.file_progress_update.emit('extracting_archive', archive_name, 0, 1)
                 self._safe_extract_archive(self.network_file_clipboard['archive'], dest_dir)
+                logging.info("[WORKER_DEBUG] Server-side paste (extraction) COMPLETED for: %s", archive_name)
+                self.file_progress_update.emit('extracting_archive', archive_name, 1, 1)
             except Exception as e:
                 logging.error('Extraction failed: %s', e, exc_info=True)
-                self.file_transfer_error.emit(str(e))
+                logging.error('[WORKER_DEBUG] Server-side paste (extraction) FAILED for: %s. Error: %s', archive_name, e)
+                self.file_transfer_error.emit(f"Kibontási hiba: {e}")
                 return
             if self.network_file_clipboard.get('operation') == 'cut':
                 src_id = self.network_file_clipboard.get('source_id')


### PR DESCRIPTION
## Summary
- add progress updates for archive extraction on server
- show progress when extracting archives in GUI
- keep mouse move logs at DEBUG level

## Testing
- `python -m py_compile gui.py worker.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_685d5650e6f08327b47625c61a35c8f2