### PR TITLE
Improve automatic connection logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ application logs activity to the console and stores settings via
 computer this instance represents (Desktop, Laptop or EliteDesk) and start or
 stop the KVM service. The correct operating mode is selected automatically.
 
+### Automatic connection
+
+The receiver continuously searches for the host using Zeroconf and
+also retries the last known IP address. This means that whether the
+host or any receiver is powered on first, they will automatically find
+each other and connect once both sides are running.
+
 The desktop acting as the host now accepts multiple client connections simultaneously. All
 connected receivers will get the forwarded input events.
 

--- a/worker.py
+++ b/worker.py
@@ -1561,6 +1561,7 @@ class KVMWorker(QObject):
                     if ip == self.worker.local_ip:
                         return  # ignore our own service
                     self.worker.server_ip = ip
+                    self.worker.last_server_ip = ip  # remember last found host
                     logging.info(f"Adó szolgáltatás megtalálva a {ip} címen.")
                     self.worker.status_update.emit(f"Adó megtalálva: {ip}. Csatlakozás...")
                 # Connection thread runs continuously, just update the server IP
@@ -1601,7 +1602,7 @@ class KVMWorker(QObject):
         hk_listener = None
 
         while self._running:
-            ip = self.server_ip
+            ip = self.server_ip or self.last_server_ip
             if not ip:
                 time.sleep(0.5)
                 continue
@@ -1620,6 +1621,7 @@ class KVMWorker(QObject):
                     self.server_socket = s
                     settings_store = QSettings(ORG_NAME, APP_NAME)
                     settings_store.setValue('network/last_server_ip', ip)
+                    self.last_server_ip = ip
                     incoming_info = None
                     self._cancel_transfer.clear()
                     logging.debug("Connected to server, cancel flag cleared")


### PR DESCRIPTION
## Summary
- enhance service discovery to remember last host IP
- fallback to the last server address when attempting to connect
- document the automatic connection behaviour in the README

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py worker.py`

------
https://chatgpt.com/codex/tasks/task_e_685fc648a87c83279928d93b51655ce1