### PR TITLE
Fix undefined hb_thread variable

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -1607,6 +1607,8 @@ class KVMWorker(QObject):
                 time.sleep(0.5)
                 continue
 
+            hb_thread = None  # Ensure heartbeat thread variable is always defined
+
             logging.debug(
                 "connect_to_server attempting to connect to %s cancel=%s",
                 ip,


### PR DESCRIPTION
## Summary
- define `hb_thread` at the start of each connection loop

## Testing
- `python -m py_compile worker.py gui.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_685fc938dde8832797380acfe92afc60