### PR TITLE
Add temporary directory option and cleanup

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,6 +8,9 @@ import sys
 APP_NAME = "KVMApp"
 ORG_NAME = "MyKVM"
 
+# Branding information
+BRAND_NAME = "UMKGL Solutions"
+
 # Hálózati beállítások
 DEFAULT_PORT = 65432
 SERVICE_TYPE = "_kvmswitch._tcp.local."


### PR DESCRIPTION
## Summary
- add branding constant
- allow configuring a custom temporary directory in the GUI
- use dedicated temp directories in worker
- ensure client-side archive cleanup
- persist custom temp path in settings

## Testing
- `pycodestyle --max-line-length=120 gui.py worker.py`
- `python -m py_compile gui.py worker.py config.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_685fdc476a848327a072732b94a97695