### PR TITLE
Add temp directory setting and cleanup improvements

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,6 +7,8 @@ import sys
 # Alkalmazás adatai a QSettings-hez
 APP_NAME = "KVMApp"
 ORG_NAME = "MyKVM"
+# Branding
+BRAND_NAME = "UMKGL Solutions"
 
 # Hálózati beállítások
 DEFAULT_PORT = 65432

--- a/gui.py
+++ b/gui.py
@@ -27,7 +27,7 @@ from PySide6.QtWidgets import (
     QProgressDialog,
 )
 from PySide6.QtGui import QIcon, QAction
-from PySide6.QtCore import QSize, QSettings, QThread, Qt, QTimer
+from PySide6.QtCore import QSize, QSettings, QThread, Qt, QTimer, QStandardPaths
 
 
 from worker import KVMWorker
@@ -68,7 +68,8 @@ class MainWindow(QMainWindow):
         'radio_desktop', 'radio_laptop', 'radio_elitedesk', 'port',
         'host_code', 'client_code', 'hotkey_label', 'autostart_check',
         'start_button', 'status_label', 'kvm_thread', 'kvm_worker',
-        'tray_icon', 'share_button', 'cut_share_button', 'paste_button', 'progress_dialog'
+        'tray_icon', 'share_button', 'cut_share_button', 'paste_button', 'progress_dialog',
+        'temp_path_edit', 'browse_temp_path_button'
     )
 
     # A MainWindow többi része változatlan...
@@ -127,6 +128,18 @@ class MainWindow(QMainWindow):
             "Automatikus indulás a rendszerrel"
         )
         other_layout.addWidget(self.autostart_check, 1, 0, 1, 2)
+
+        other_layout.addWidget(QLabel("Ideiglenes mappa:"), 2, 0)
+        temp_path_layout = QHBoxLayout()
+        self.temp_path_edit = QLineEdit()
+        self.temp_path_edit.setReadOnly(True)
+        temp_path_layout.addWidget(self.temp_path_edit)
+
+        self.browse_temp_path_button = QPushButton("Tallózás...")
+        self.browse_temp_path_button.clicked.connect(self.browse_temp_directory)
+        temp_path_layout.addWidget(self.browse_temp_path_button)
+
+        other_layout.addLayout(temp_path_layout, 2, 1)
         other_box.setLayout(other_layout)
         main_layout.addWidget(other_box)
 
@@ -178,6 +191,7 @@ class MainWindow(QMainWindow):
                 'host': int(self.host_code.text()),
                 'client': int(self.client_code.text()),
             },
+            'temp_path': self.temp_path_edit.text(),
         }
 
     def toggle_kvm_service(self):
@@ -230,6 +244,7 @@ class MainWindow(QMainWindow):
         settings.setValue("monitor/client_code", self.client_code.text())
         autostart_enabled = self.autostart_check.isChecked()
         settings.setValue("other/autostart", autostart_enabled)
+        settings.setValue("other/temp_path", self.temp_path_edit.text())
         # JAVÍTÁS: Itt hívjuk meg a registry-kezelő függvényt
         try:
             set_autostart(autostart_enabled)
@@ -248,6 +263,9 @@ class MainWindow(QMainWindow):
         self.autostart_check.setChecked(
             settings.value("other/autostart", False, type=bool)
         )
+        default_temp_path = QStandardPaths.writableLocation(QStandardPaths.TempLocation)
+        self.temp_path_edit.setText(settings.value("other/temp_path", default_temp_path))
+        self.temp_path_edit.textChanged.connect(self.save_settings)
         self.radio_desktop.toggled.connect(self.save_settings)
         self.radio_laptop.toggled.connect(self.save_settings)
         self.radio_elitedesk.toggled.connect(self.save_settings)
@@ -303,6 +321,12 @@ class MainWindow(QMainWindow):
         self.stop_kvm_service()
         time.sleep(0.2)
         QApplication.instance().quit()
+
+    def browse_temp_directory(self):
+        directory = QFileDialog.getExistingDirectory(self, "Ideiglenes mappa kiválasztása")
+        if directory:
+            self.temp_path_edit.setText(directory)
+            self.save_settings()
 
     def share_network_file(self, cut: bool = False):
         if not self.kvm_worker:


### PR DESCRIPTION
## Summary
- introduce `BRAND_NAME` constant
- add Temporary Directory selection to the GUI and store it in settings
- calculate progress speed and ETR during transfers
- create a branded temporary directory for each transfer and clean it up
- fix client-side send logic and cleanup of partial downloads

## Testing
- `python -m py_compile config.py gui.py worker.py`

------
https://chatgpt.com/codex/tasks/task_e_685fde5141748327bc01600e38f5dcd4