### PR TITLE
Increase GUI window size

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -79,7 +79,8 @@ class MainWindow(QMainWindow):
         self.setWindowIcon(QIcon(ICON_PATH))
         # Prevent resizing during runtime
         # Provide a bit more vertical room so texts are not cramped
-        self.setFixedSize(QSize(450, 480))
+        # Slightly increased height so long texts fit within the window
+        self.setFixedSize(QSize(450, 520))
 
         central_widget = QWidget()
         self.setCentralWidget(central_widget)
@@ -164,7 +165,7 @@ class MainWindow(QMainWindow):
         self.status_label = QLabel("Állapot: Inaktív")
         self.status_label.setWordWrap(True)
         self.status_label.setAlignment(Qt.AlignTop)
-        self.status_label.setFixedHeight(70)
+        self.status_label.setFixedHeight(90)
         main_layout.addWidget(self.status_label)
 
         self.kvm_thread = None


### PR DESCRIPTION
## Summary
- expand main window's fixed height so text fits
- enlarge status label height

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`
- `python main.py --minimized` *(fails: libEGL.so.1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe43185608327b244b63dbb574656