### PR TITLE
Add drive-based temp folder selection

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,6 +10,13 @@ ORG_NAME = "MyKVM"
 # Branding
 BRAND_NAME = "UMKGL Solutions"
 
+# Base folder structure for temporary files under the selected drive
+TEMP_DIR_PARTS = [
+    "UMKGL Solutions",
+    "Szamitepvalto-Extravaganza",
+    "Ideiglenes fájlok",
+]
+
 # Hálózati beállítások
 DEFAULT_PORT = 65432
 SERVICE_TYPE = "_kvmswitch._tcp.local."

--- a/gui.py
+++ b/gui.py
@@ -25,13 +25,15 @@ from PySide6.QtWidgets import (
     QMenu,
     QFileDialog,
     QProgressDialog,
+    QInputDialog,
+    QMessageBox,
 )
 from PySide6.QtGui import QIcon, QAction
 from PySide6.QtCore import QSize, QSettings, QThread, Qt, QTimer, QStandardPaths
 
 
 from worker import KVMWorker
-from config import APP_NAME, ORG_NAME, DEFAULT_PORT, ICON_PATH
+from config import APP_NAME, ORG_NAME, DEFAULT_PORT, ICON_PATH, TEMP_DIR_PARTS
 
 MB = 1024 * 1024
 
@@ -323,9 +325,37 @@ class MainWindow(QMainWindow):
         QApplication.instance().quit()
 
     def browse_temp_directory(self):
-        directory = QFileDialog.getExistingDirectory(self, "Ideiglenes mappa kiválasztása")
-        if directory:
-            self.temp_path_edit.setText(directory)
+        """Allow selecting only drive roots and create the temp folder."""
+        import string
+
+        # Detect available drives on Windows
+        drives = [f"{d}:\\" for d in string.ascii_uppercase if os.path.exists(f"{d}:\\")]
+
+        if not drives:
+            QMessageBox.warning(self, "Hiba", "Nem találhatók elérhető meghajtók.")
+            return
+
+        drive, ok = QInputDialog.getItem(
+            self,
+            "Lemez kiválasztása",
+            "Válassz meghajtót az ideiglenes fájlokhoz:",
+            drives,
+            editable=False,
+        )
+
+        if ok and drive:
+            target_dir = os.path.join(drive, *TEMP_DIR_PARTS)
+            try:
+                os.makedirs(target_dir, exist_ok=True)
+            except OSError as e:
+                QMessageBox.warning(
+                    self,
+                    "Hiba",
+                    f"Nem sikerült a mappát létrehozni: {e}"
+                )
+                return
+
+            self.temp_path_edit.setText(target_dir)
             self.save_settings()
 
     def share_network_file(self, cut: bool = False):

--- a/worker.py
+++ b/worker.py
@@ -25,6 +25,7 @@ from config import (
     APP_NAME,
     ORG_NAME,
     BRAND_NAME,
+    TEMP_DIR_PARTS,
     VK_CTRL,
     VK_CTRL_R,
     VK_NUMPAD0,
@@ -180,7 +181,9 @@ class KVMWorker(QObject):
         """
         base_path = self.settings.get('temp_path') or tempfile.gettempdir()
 
-        app_temp_path = os.path.join(base_path, BRAND_NAME, APP_NAME)
+        # Construct the root path for all temporary files using the configured
+        # drive and the constant directory structure.
+        app_temp_path = os.path.join(base_path, *TEMP_DIR_PARTS)
 
         try:
             os.makedirs(app_temp_path, exist_ok=True)


### PR DESCRIPTION
## Summary
- allow selecting only drive roots for temporary files
- automatically create `UMKGL Solutions/Szamitepvalto-Extravaganza/Ideiglenes fájlok` on the chosen drive
- adjust worker to use the configured path

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`
- `python -m py_compile gui.py worker.py config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fe4a0ba248327be8cc4ead4457897