### PR TITLE
Add connection timeout for faster reconnection

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -1566,8 +1566,10 @@ class KVMWorker(QObject):
             try:
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                     s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                    s.settimeout(5.0)
                     logging.info(f"Connecting to {ip}:{self.settings['port']}")
                     s.connect((ip, self.settings['port']))
+                    s.settimeout(None)
                     self.server_socket = s
                     settings_store = QSettings(ORG_NAME, APP_NAME)
                     settings_store.setValue('network/last_server_ip', ip)


### PR DESCRIPTION
## Summary
- ensure the TCP client connection attempt times out quickly

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_685fe3db13888327bdbd5d049cc1cddc