### PR TITLE
Fix int overflow by removing large file signal

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -213,7 +213,6 @@ class MainWindow(QMainWindow):
         self.kvm_worker.status_update.connect(self.on_status_update)
         self.kvm_worker.update_progress_display.connect(self.update_progress_display)
         self.kvm_worker.file_transfer_error.connect(self.on_transfer_error)
-        self.kvm_worker.incoming_upload_started.connect(self.on_incoming_upload_started)
         self.kvm_thread.start()
         self.start_button.setText("KVM Szolgáltatás Leállítása")
         self.set_controls_enabled(False)
@@ -399,21 +398,6 @@ class MainWindow(QMainWindow):
         self.progress_dialog.setLabelText(f"{title} előkészítése...")
         logging.info("[GUI_DEBUG] show_progress_dialog: Label set to: %s", self.progress_dialog.labelText())
         self.progress_dialog.show()
-
-    def on_incoming_upload_started(self, filename: str, total_size: int):
-        logging.info(
-            "[GUI_DEBUG] on_incoming_upload_started triggered. Filename: %s, Size: %d",
-            filename,
-            total_size,
-        )
-        self.show_progress_dialog("Fájl fogadása")
-        logging.info(
-            "[GUI_DEBUG] on_incoming_upload_started: Progress dialog shown. Current label: %s",
-            self.progress_dialog.labelText() if self.progress_dialog else "N/A",
-        )
-        logging.info(
-            "[GUI_DEBUG] on_incoming_upload_started: initial 0%% progress emitted",
-        )
 
     def update_progress_display(self, percentage: int, label: str):
         """Receives a pre-calculated percentage and label, and applies them directly."""

--- a/worker.py
+++ b/worker.py
@@ -72,7 +72,6 @@ class KVMWorker(QObject):
     status_update = Signal(str)
     update_progress_display = Signal(int, str)  # percentage, label text
     file_transfer_error = Signal(str)
-    incoming_upload_started = Signal(str, int)
 
     def __init__(self, settings):
         super().__init__()
@@ -967,11 +966,6 @@ class KVMWorker(QObject):
                                     self.file_transfer_error.emit(str(e))
                                     self._clear_network_file_clipboard()
                                     break
-                                self.incoming_upload_started.emit(
-                                    data.get('name'),
-                                    data.get('size', 0)
-                                )
-                                logging.info("[WORKER_DEBUG] Emitting incoming_upload_started for: %s, size: %s", data.get('name'), data.get('size', 0))
                                 self._cancel_transfer.clear()
                                 logging.debug("Receiving upload, cancel flag cleared")
                                 sock.settimeout(TRANSFER_TIMEOUT)
@@ -989,6 +983,7 @@ class KVMWorker(QObject):
                                 }
                                 last_percentage = -1
                                 last_emit_time = time.time()
+                                # Start progress display at 0% using the safe signal
                                 self.update_progress_display.emit(0, f"{upload_info['name']}: 0MB / {upload_info['size']/1024/1024:.1f}MB")
                             elif data.get('type') == 'file_chunk':
                                 if upload_info:


### PR DESCRIPTION
## Summary
- remove the `incoming_upload_started` signal from `worker.py`
- remove use of that signal from the file receiver
- drop the connection and handler for the signal in `gui.py`

## Testing
- `pycodestyle gui.py worker.py`

------
https://chatgpt.com/codex/tasks/task_e_686069c2cc2083279c42e6470a1caf8c