### PR TITLE
Fix client input grab on connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ also retries the last known IP address. This means that whether the
 host or any receiver is powered on first, they will automatically find
 each other and connect once both sides are running.
 
+On receiver machines the local keyboard and mouse are no longer grabbed as
+soon as a connection is established. The host must explicitly activate a KVM
+session (via hotkey or the GUI) before control is transferred.
+
 The desktop acting as the host now accepts multiple client connections simultaneously. All
 connected receivers will get the forwarded input events.
 

--- a/kvm/network/worker.py
+++ b/kvm/network/worker.py
@@ -152,7 +152,8 @@ class KVMWorker(QObject):
         self.clipboard_thread = threading.Thread(target=self._clipboard_loop_client, args=(s,), daemon=True)
         self.clipboard_thread.start()
         self.switch_monitor = True
-        self.input_streamer.start()
+        # Avoid capturing local input on the client. The streamer is only
+        # started when the host explicitly activates a KVM session.
 
         try:
             self._client_recv_loop(s)


### PR DESCRIPTION
## Summary
- prevent client mode from grabbing the mouse/keyboard immediately
- note the new behaviour in the README

## Testing
- `pycodestyle --max-line-length=120 kvm/gui/gui.py tools/clipboard_sync.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6862605058c0832790fe37c8a8aaa9ff