### PR TITLE
Fix input streamer restart issue

### DIFF
--- a/kvm/input/input_streamer.py
+++ b/kvm/input/input_streamer.py
@@ -60,6 +60,9 @@ class InputStreamer:
         self.vk_codes.clear()
         self.special_keys.clear()
         self.pressed_keys.clear()
+        if self.thread and self.thread is not threading.current_thread():
+            self.thread.join()
+        self.thread = None
 
     # ------------------------------------------------------------------
     def _run(self):


### PR DESCRIPTION
## Summary
- ensure the `InputStreamer` thread fully stops before starting again
- join and reset the thread in `stop()`

## Testing
- `pycodestyle --max-line-length=120 kvm/gui/gui.py tools/clipboard_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_686261e152088327b8f2334d01191185