### PR TITLE
Fix missing shutil import in worker

### DIFF
--- a/kvm/network/worker.py
+++ b/kvm/network/worker.py
@@ -7,6 +7,7 @@ import threading
 import time
 import tempfile
 import zipfile
+import shutil
 
 import msgpack
 import pyperclip


### PR DESCRIPTION
## Summary
- fix NameError by importing `shutil` in `kvm/network/worker.py`

## Testing
- `pycodestyle --max-line-length=120 kvm/gui/gui.py tools/clipboard_sync.py kvm/network/worker.py`
- `python -m py_compile kvm/network/worker.py`

------
https://chatgpt.com/codex/tasks/task_e_686262209b68832795a8356b5cbf6583