### PR TITLE
Add client reconnection loop

### DIFF
--- a/kvm/network/networking.py
+++ b/kvm/network/networking.py
@@ -59,6 +59,8 @@ class KVMServiceListener:
         if info:
             ip = socket.inet_ntoa(info.addresses[0])
             logging.warning("Adó szolgáltatás eltűnt: %s", ip)
+            if ip == self.worker.last_server_ip:
+                self.worker._start_reconnect_loop()
         else:
             logging.warning("Adó szolgáltatás eltűnt")
-
+            self.worker._start_reconnect_loop()


### PR DESCRIPTION
## Summary
- make the client reconnect to the last known host automatically
- trigger reconnection after disconnect or service removal

## Testing
- `pycodestyle --max-line-length=120 kvm/gui/gui.py tools/clipboard_sync.py kvm/network/worker.py kvm/network/networking.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68626269775c8327bcb25a4c29987ba0