### PR TITLE
Fix connection reset exception

### DIFF
--- a/kvm/network/worker.py
+++ b/kvm/network/worker.py
@@ -174,7 +174,10 @@ class KVMWorker(QObject):
         def recvall(s, n):
             data = b''
             while len(data) < n:
-                chunk = s.recv(n - len(data))
+                try:
+                    chunk = s.recv(n - len(data))
+                except OSError:
+                    return None
                 if not chunk:
                     return None
                 data += chunk
@@ -247,7 +250,10 @@ class KVMWorker(QObject):
         def recvall(s, n):
             data = b''
             while len(data) < n:
-                chunk = s.recv(n - len(data))
+                try:
+                    chunk = s.recv(n - len(data))
+                except OSError:
+                    return None
                 if not chunk:
                     return None
                 data += chunk
@@ -271,7 +277,7 @@ class KVMWorker(QObject):
         last_emit = time.time()
         try:
             while self._running:
-                raw = sock.recv(4)
+                raw = recvall(sock, 4)
                 if not raw:
                     break
                 msg_len = struct.unpack('!I', raw)[0]


### PR DESCRIPTION
## Summary
- handle connection reset errors while receiving data
- use the safer recvall implementation for server-side monitoring

## Testing
- `pytest -q`
- `pip install -q -r requirements.txt`
- `flake8` *(fails: command not found)*
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_686262a169148327bd857291e29d8e21