### PR TITLE
Fix stuck modifier keys when restarting service

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -231,6 +231,8 @@ class KVMWorker(FileTransferMixin, ConnectionMixin, QObject):
 
     def run(self):
         logging.info(f"Worker elindítva {self.settings['role']} módban.")
+        # Ensure no stuck modifier keys remain from a previous run
+        self.release_hotkey_keys()
         if self.settings['role'] == 'ado':
             self.run_server()
         else:


### PR DESCRIPTION
### **User description**
## Summary
- release previously pressed hotkey keys when starting the worker

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`
- `python -m py_compile main.py gui.py worker.py connection_utils.py input_streaming.py clipboard_sync.py file_transfer.py`

------
https://chatgpt.com/codex/tasks/task_e_68632785cb908327a7290912b2cd7696


___

### **PR Type**
Bug fix


___

### **Description**
- Release stuck modifier keys when starting worker

- Prevent keyboard state issues after service restart


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Service Start"] --> B["Release Hotkey Keys"] --> C["Normal Operation"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker.py</strong><dd><code>Release modifier keys on worker startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker.py

<li>Added <code>release_hotkey_keys()</code> call at the beginning of <code>run()</code> method<br> <li> Ensures no stuck modifier keys remain from previous runs


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/154/files#diff-ef0ecc97a9e678e23ad77ea341fd81fb27bb2e63608a6556074ca2225ae69330">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>