### PR TITLE
Improve client removal logic

### DIFF
--- a/connection_utils.py
+++ b/connection_utils.py
@@ -397,10 +397,6 @@ class ConnectionMixin:
                     break
         finally:
             logging.warning(f"Kliens lecsatlakozott: {addr}.")
-            try:
-                sock.close()
-            except Exception:
-                pass
             if upload_info and upload_info.get('temp_dir'):
                 logging.warning("Cleaning up incomplete download directory: %s", upload_info['temp_dir'])
                 try:
@@ -411,14 +407,7 @@ class ConnectionMixin:
             upload_info = None
             self._cancel_transfer.clear()
             self._clear_network_file_clipboard()
-            if sock in self.client_sockets:
-                self.client_sockets.remove(sock)
-            if sock in self.client_infos:
-                del self.client_infos[sock]
-            if sock == self.active_client:
-                self.active_client = None
-            if self.kvm_active and not self.client_sockets:
-                self.deactivate_kvm(reason="all clients disconnected")
+            self._remove_client(sock, reason="connection lost or error")
             logging.debug("monitor_client exit for %s", client_name)
     def run_client(self):
         """Run the client mode with persistent discovery and reconnect logic."""

--- a/input_streaming.py
+++ b/input_streaming.py
@@ -92,17 +92,9 @@ def stream_inputs(worker):
                         unsent_events.append(event)
                     to_remove.append(sock)
             for s in to_remove:
-                try:
-                    s.close()
-                except Exception:
-                    pass
-                if s in worker.client_sockets:
-                    worker.client_sockets.remove(s)
-                if s in worker.client_infos:
-                    del worker.client_infos[s]
                 if s == worker.active_client:
-                    worker.active_client = None
                     active_lost = True
+                worker._remove_client(s, reason="send failed or timeout")
             if active_lost:
                 worker.status_update.emit("Kapcsolat megszakadt. Várakozás új kliensre...")
             if to_remove and not worker.client_sockets:


### PR DESCRIPTION
## Summary
- implement `_remove_client` for safer client cleanup in `worker.py`
- use `_remove_client` in `monitor_client` and `input_streaming`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863aa919c20832795e1fc45b81a5c5f