### PR TITLE
Prevent cursor recentering on hotkey

### DIFF
--- a/input_streaming.py
+++ b/input_streaming.py
@@ -38,13 +38,18 @@ def stream_inputs(worker):
     try:
         root = tkinter.Tk()
         root.withdraw()
-        center_x, center_y = root.winfo_screenwidth() // 2, root.winfo_screenheight() // 2
+        center_x, center_y = (
+            root.winfo_screenwidth() // 2,
+            root.winfo_screenheight() // 2,
+        )
         root.destroy()
     except Exception:
         center_x, center_y = 800, 600
 
-    host_mouse_controller.position = (center_x, center_y)
-    last_pos = {'x': center_x, 'y': center_y}
+    last_pos = {
+        'x': host_mouse_controller.position[0],
+        'y': host_mouse_controller.position[1],
+    }
     is_warping = False
 
     send_queue = queue.Queue(maxsize=SEND_QUEUE_MAXSIZE)


### PR DESCRIPTION
## Summary
- maintain host mouse position when starting a KVM session

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py input_streaming.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863afc55a708327b2ed9f128e04d5fb