### PR TITLE
Fix race on hotkey listener shutdown

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -210,6 +210,7 @@ class KVMWorker(FileTransferMixin, ConnectionMixin, QObject):
         if listener is not None:
             try:
                 listener.stop()
+                listener.join()
             except Exception:
                 pass
             try:


### PR DESCRIPTION
## Summary
- wait for the idle hotkey listener thread to end before launching the suppressing listener
- ensure server startup/shutdown uses worker hotkey management only

## Testing
- `python -m py_compile worker.py connection_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6863b9a5904c8327991b032ef9cc8fd0