### PR TITLE
Fix initial mouse warp in input streaming

### DIFF
--- a/input_streaming.py
+++ b/input_streaming.py
@@ -46,10 +46,10 @@ def stream_inputs(worker):
     except Exception:
         center_x, center_y = 800, 600
 
-    last_pos = {
-        'x': host_mouse_controller.position[0],
-        'y': host_mouse_controller.position[1],
-    }
+    # FIX: Explicitly center the mouse at the start of streaming
+    host_mouse_controller.position = (center_x, center_y)
+    # Initialize last_pos with the now-guaranteed center coordinates
+    last_pos = {'x': center_x, 'y': center_y}
     is_warping = False
 
     send_queue = queue.Queue(maxsize=SEND_QUEUE_MAXSIZE)


### PR DESCRIPTION
## Summary
- center the mouse cursor before starting streaming
- initialize `last_pos` with the centered coordinates

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py input_streaming.py`
- `python -m py_compile input_streaming.py`

------
https://chatgpt.com/codex/tasks/task_e_68644940eb108327ba130dfa42850a23