### PR TITLE
Fix SyntaxError in worker

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -1103,11 +1103,18 @@ class KVMWorker(QObject):
                                     self._set_clipboard(text)
                             else:
                                 self.file_handler.handle_network_message(data, s)
+                        except Exception as e:
+                            logging.error(
+                                f"Hiba a szervertől kapott üzenet feldolgozásakor: {e}",
+                                exc_info=True,
+                            )
 
             except Exception as e:
                 if self._running:
                     logging.error(f"Csatlakozás sikertelen: {e}", exc_info=True)
-                    self.status_update.emit(f"Kapcsolat sikertelen: {e}. Újrapróbálkozás 5 mp múlva...")
+                    self.status_update.emit(
+                        f"Kapcsolat sikertelen: {e}. Újrapróbálkozás 5 mp múlva..."
+                    )
 
             finally:
                 logging.info("Connection to server closed")


### PR DESCRIPTION
## Summary
- fix indentation in `worker.py` by adding missing inner `except`
- log errors when processing server messages

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`
- `python -m py_compile worker.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_6864ea4731848327b38eb39a28b32c4e