### PR TITLE
Increase file transfer timeout

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -42,7 +42,9 @@ SEND_QUEUE_MAXSIZE = 200
 # File transfer chunk size
 FILE_CHUNK_SIZE = 65536
 # Socket timeout (seconds) during file transfers
-TRANSFER_TIMEOUT = 30
+# Timeout while waiting for file transfer data
+# Increased from 30 to 90 seconds to handle slower networks
+TRANSFER_TIMEOUT = 90
 # Minimum delay between progress updates
 PROGRESS_UPDATE_INTERVAL = 0.5
 


### PR DESCRIPTION
### **User description**
## Summary
- allow slower transfers by upping `TRANSFER_TIMEOUT` to 90s
- add log messages when metadata or chunks fail to send

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869060c3264832797e55d6c7258b902


___

### **PR Type**
Enhancement


___

### **Description**
- Increase file transfer timeout from 30 to 90 seconds

- Add error logging for failed metadata and chunk sends

- Improve handling of slower network connections


___

### **Changes diagram**

```mermaid
flowchart LR
  A["File Transfer"] --> B["Timeout Increased"]
  A --> C["Error Logging Added"]
  B --> D["30s → 90s"]
  C --> E["Metadata Failures"]
  C --> F["Chunk Send Failures"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file_transfer.py</strong><dd><code>Enhanced timeout and error logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

file_transfer.py

<li>Increase <code>TRANSFER_TIMEOUT</code> from 30 to 90 seconds<br> <li> Add error logging for failed metadata sends<br> <li> Add error logging for failed file chunk sends<br> <li> Include detailed comments explaining timeout change


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/195/files#diff-518373b47a3ee594e57276192848e7a605aca7ace022adb0ba95fc9bade67eff">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker.py</strong><dd><code>Updated transfer timeout constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker.py

<li>Update <code>TRANSFER_TIMEOUT</code> constant from 30 to 90 seconds<br> <li> Add explanatory comment about timeout increase


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/195/files#diff-ef0ecc97a9e678e23ad77ea341fd81fb27bb2e63608a6556074ca2225ae69330">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>