### PR TITLE
Fix hotkey detection regression

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -300,13 +300,13 @@ class KVMWorker(QObject):
         )
         logging.info("Zeroconf szolgáltatás regisztrálva.")
 
-        # Definitions for NumLock OFF state using VK codes
-        hotkey_desktop_l_numoff = {VK_LSHIFT, VK_INSERT}
-        hotkey_desktop_r_numoff = {VK_RSHIFT, VK_INSERT}
-        hotkey_laptop_l_numoff = {VK_LSHIFT, VK_END}
-        hotkey_laptop_r_numoff = {VK_RSHIFT, VK_END}
-        hotkey_elitdesk_l_numoff = {VK_LSHIFT, VK_NUMPAD2}
-        hotkey_elitdesk_r_numoff = {VK_RSHIFT, VK_NUMPAD2}
+        # Definitions for NumLock OFF state based on diagnostic results
+        hotkey_desktop_l_numoff = {keyboard.Key.shift, keyboard.Key.insert}
+        hotkey_desktop_r_numoff = {keyboard.Key.shift_r, keyboard.Key.insert}
+        hotkey_laptop_l_numoff = {keyboard.Key.shift, keyboard.Key.end}
+        hotkey_laptop_r_numoff = {keyboard.Key.shift_r, keyboard.Key.end}
+        hotkey_elitdesk_l_numoff = {keyboard.Key.shift, VK_NUMPAD2}
+        hotkey_elitdesk_r_numoff = {keyboard.Key.shift_r, VK_NUMPAD2}
 
         # Definitions for NumLock ON state (fallback using VK codes)
         hotkey_desktop_l_numon = {VK_LSHIFT, VK_NUMPAD0}
@@ -332,8 +332,8 @@ class KVMWorker(QObject):
             )
 
             if (
-                hotkey_desktop_l_numoff.issubset(current_pressed_vk_codes)
-                or hotkey_desktop_r_numoff.issubset(current_pressed_vk_codes)
+                hotkey_desktop_l_numoff.issubset(current_pressed_special_keys)
+                or hotkey_desktop_r_numoff.issubset(current_pressed_special_keys)
             ) or (
                 hotkey_desktop_l_numon.issubset(current_pressed_vk_codes)
                 or hotkey_desktop_r_numon.issubset(current_pressed_vk_codes)
@@ -341,8 +341,8 @@ class KVMWorker(QObject):
                 logging.info("!!! Asztal gyorsbillentyű észlelve! Visszaváltás... !!!")
                 pending_client = 'desktop'
             elif (
-                hotkey_laptop_l_numoff.issubset(current_pressed_vk_codes)
-                or hotkey_laptop_r_numoff.issubset(current_pressed_vk_codes)
+                hotkey_laptop_l_numoff.issubset(current_pressed_special_keys)
+                or hotkey_laptop_r_numoff.issubset(current_pressed_special_keys)
             ) or (
                 hotkey_laptop_l_numon.issubset(current_pressed_vk_codes)
                 or hotkey_laptop_r_numon.issubset(current_pressed_vk_codes)
@@ -350,8 +350,12 @@ class KVMWorker(QObject):
                 logging.info("!!! Laptop gyorsbillentyű észlelve! Váltás... !!!")
                 pending_client = 'laptop'
             elif (
-                hotkey_elitdesk_l_numoff.issubset(current_pressed_vk_codes)
-                or hotkey_elitdesk_r_numoff.issubset(current_pressed_vk_codes)
+                hotkey_elitdesk_l_numoff.issubset(
+                    current_pressed_special_keys.union(current_pressed_vk_codes)
+                )
+                or hotkey_elitdesk_r_numoff.issubset(
+                    current_pressed_special_keys.union(current_pressed_vk_codes)
+                )
             ) or (
                 hotkey_elitdesk_l_numon.issubset(current_pressed_vk_codes)
                 or hotkey_elitdesk_r_numon.issubset(current_pressed_vk_codes)
@@ -907,7 +911,6 @@ class KVMWorker(QObject):
         
         pressed_keys = set()
         current_vks = set()
-        current_special_keys = set()
 
         def get_vk(key):
             if hasattr(key, "vk") and key.vk is not None:
@@ -916,23 +919,8 @@ class KVMWorker(QObject):
                 return key.value.vk
             return None
 
-        hotkey_desktop_l_numoff = {VK_LSHIFT, VK_INSERT}
-        hotkey_desktop_r_numoff = {VK_RSHIFT, VK_INSERT}
-        hotkey_laptop_l_numoff = {VK_LSHIFT, VK_END}
-        hotkey_laptop_r_numoff = {VK_RSHIFT, VK_END}
-        hotkey_elitdesk_l_numoff = {VK_LSHIFT, VK_NUMPAD2}
-        hotkey_elitdesk_r_numoff = {VK_RSHIFT, VK_NUMPAD2}
-
-        hotkey_desktop_l_numon = {VK_LSHIFT, VK_NUMPAD0}
-        hotkey_desktop_r_numon = {VK_RSHIFT, VK_NUMPAD0}
-        hotkey_laptop_l_numon = {VK_LSHIFT, VK_NUMPAD1}
-        hotkey_laptop_r_numon = {VK_RSHIFT, VK_NUMPAD1}
-        hotkey_elitdesk_l_numon = {VK_LSHIFT, VK_NUMPAD2}
-        hotkey_elitdesk_r_numon = {VK_RSHIFT, VK_NUMPAD2}
-
-
         def on_key(k, p):
-            """Forward keyboard events to the client and kezelje a gyorsbillentyűt."""
+            """Forward keyboard events to the client and handle the hotkey."""
             try:
                 vk = get_vk(k)
                 if vk is not None:
@@ -940,19 +928,10 @@ class KVMWorker(QObject):
                         current_vks.add(vk)
                     else:
                         current_vks.discard(vk)
-                if isinstance(k, keyboard.Key):
-                    if p:
-                        current_special_keys.add(k)
-                    else:
-                        current_special_keys.discard(k)
 
                 if (
-                    hotkey_desktop_l_numoff.issubset(current_vks)
-                    or hotkey_desktop_r_numoff.issubset(current_vks)
-                    or (
-                        (VK_LSHIFT in current_vks or VK_RSHIFT in current_vks)
-                        and VK_NUMPAD0 in current_vks
-                    )
+                    (VK_LSHIFT in current_vks or VK_RSHIFT in current_vks)
+                    and VK_NUMPAD0 in current_vks
                 ):
                     logging.info("!!! Visszaváltás a hosztra (Shift+Numpad0) észlelve a streaming alatt !!!")
                     # Send key releases to the client before disabling streaming
@@ -964,12 +943,8 @@ class KVMWorker(QObject):
                     self.deactivate_kvm(switch_monitor=True, reason='streaming hotkey')
                     return
                 if (
-                    hotkey_laptop_l_numoff.issubset(current_vks)
-                    or hotkey_laptop_r_numoff.issubset(current_vks)
-                    or (
-                        (VK_LSHIFT in current_vks or VK_RSHIFT in current_vks)
-                        and VK_NUMPAD1 in current_vks
-                    )
+                    (VK_LSHIFT in current_vks or VK_RSHIFT in current_vks)
+                    and VK_NUMPAD1 in current_vks
                 ):
                     logging.debug(f"Hotkey detected for laptop with current_vks={current_vks}")
                     for vk_code in [VK_LSHIFT, VK_RSHIFT, VK_NUMPAD1]:
@@ -980,12 +955,8 @@ class KVMWorker(QObject):
                     self.toggle_client_control('laptop', switch_monitor=False, release_keys=False)
                     return
                 if (
-                    hotkey_elitdesk_l_numoff.issubset(current_vks)
-                    or hotkey_elitdesk_r_numoff.issubset(current_vks)
-                    or (
-                        (VK_LSHIFT in current_vks or VK_RSHIFT in current_vks)
-                        and VK_NUMPAD2 in current_vks
-                    )
+                    (VK_LSHIFT in current_vks or VK_RSHIFT in current_vks)
+                    and VK_NUMPAD2 in current_vks
                 ):
                     logging.debug(f"Hotkey detected for elitedesk with current_vks={current_vks}")
                     for vk_code in [VK_LSHIFT, VK_RSHIFT, VK_NUMPAD2]:


### PR DESCRIPTION
### **User description**
## Summary
- restore working Shift+Numpad hotkey detection

## Testing
- `python -m py_compile worker.py gui.py main.py build_exe.py clipboard_sync.py config.py file_transfer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686907754bd48327b5ffd4e515a95c93


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Shift+Numpad hotkey detection regression

- Restore proper keyboard event handling for NumLock OFF state

- Simplify hotkey detection logic in streaming mode

- Update key tracking to use appropriate key sets


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Hotkey Detection"] --> B["NumLock OFF State"]
  A --> C["NumLock ON State"]
  B --> D["Special Keys Set"]
  C --> E["VK Codes Set"]
  D --> F["Fixed Detection"]
  E --> F
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker.py</strong><dd><code>Fix hotkey detection for Shift+Numpad combinations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker.py

<li>Replace VK codes with keyboard.Key constants for NumLock OFF hotkeys<br> <li> Update hotkey detection to use <code>current_pressed_special_keys</code> set<br> <li> Simplify streaming mode hotkey logic by removing redundant checks<br> <li> Fix ElitDesk hotkey detection using union of special keys and VK codes


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/196/files#diff-ef0ecc97a9e678e23ad77ea341fd81fb27bb2e63608a6556074ca2225ae69330">+24/-53</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>