### PR TITLE
Improve hotkey behavior when multiple clients connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ each other and connect once both sides are running.
 The desktop acting as the host now accepts multiple client connections simultaneously. All
 connected receivers will get the forwarded input events.
 
+### Host hotkeys
+
+While running on the desktop, use the following shortcuts to control the connected machines:
+
+- **Shift + Numpad 1** – Take control of the laptop
+- **Shift + Numpad 2** – Take control of the EliteDesk and switch the monitor input
+- **Shift + Numpad 0** – Return control to the desktop and restore the monitor input
+
+Switching directly between the laptop and EliteDesk is disabled. Press `Shift + Numpad 0` first to
+return to the desktop before activating the other client.
+
 Slow clients that cannot keep up with the stream are disconnected after a short
 send timeout so they no longer cause lag for others. Input events are queued up
 to a limited size and older ones are discarded if necessary. The application

--- a/worker.py
+++ b/worker.py
@@ -948,26 +948,34 @@ class KVMWorker(QObject):
                     (VK_LSHIFT in current_vks or VK_RSHIFT in current_vks)
                     and VK_NUMPAD1 in current_vks
                 ):
-                    logging.debug(f"Hotkey detected for laptop with current_vks={current_vks}")
-                    for vk_code in [VK_LSHIFT, VK_RSHIFT, VK_NUMPAD1]:
-                        if vk_code in current_vks:
-                            send({"type": "key", "key_type": "vk", "key": vk_code, "pressed": False})
-                            pressed_keys.discard(("vk", vk_code))
-                    current_vks.clear()
-                    self.toggle_client_control('laptop', switch_monitor=False, release_keys=False)
-                    return
+                    active_name = self.client_infos.get(self.active_client, "").lower()
+                    logging.debug(
+                        f"Hotkey detected for laptop with current_vks={current_vks} while active={active_name}"
+                    )
+                    if active_name != "elitedesk":
+                        for vk_code in [VK_LSHIFT, VK_RSHIFT, VK_NUMPAD1]:
+                            if vk_code in current_vks:
+                                send({"type": "key", "key_type": "vk", "key": vk_code, "pressed": False})
+                                pressed_keys.discard(("vk", vk_code))
+                        current_vks.clear()
+                        self.toggle_client_control('laptop', switch_monitor=False, release_keys=False)
+                        return
                 if (
                     (VK_LSHIFT in current_vks or VK_RSHIFT in current_vks)
                     and VK_NUMPAD2 in current_vks
                 ):
-                    logging.debug(f"Hotkey detected for elitedesk with current_vks={current_vks}")
-                    for vk_code in [VK_LSHIFT, VK_RSHIFT, VK_NUMPAD2]:
-                        if vk_code in current_vks:
-                            send({"type": "key", "key_type": "vk", "key": vk_code, "pressed": False})
-                            pressed_keys.discard(("vk", vk_code))
-                    current_vks.clear()
-                    self.toggle_client_control('elitedesk', switch_monitor=True, release_keys=False)
-                    return
+                    active_name = self.client_infos.get(self.active_client, "").lower()
+                    logging.debug(
+                        f"Hotkey detected for elitedesk with current_vks={current_vks} while active={active_name}"
+                    )
+                    if active_name != "laptop":
+                        for vk_code in [VK_LSHIFT, VK_RSHIFT, VK_NUMPAD2]:
+                            if vk_code in current_vks:
+                                send({"type": "key", "key_type": "vk", "key": vk_code, "pressed": False})
+                                pressed_keys.discard(("vk", vk_code))
+                        current_vks.clear()
+                        self.toggle_client_control('elitedesk', switch_monitor=True, release_keys=False)
+                        return
 
                 if hasattr(k, "char") and k.char is not None:
                     key_type = "char"


### PR DESCRIPTION
## Summary
- document desktop hotkeys in README
- prevent switching directly between laptop and EliteDesk

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py worker.py main.py config.py` *(fails: E722, E303, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68690b6093fc83278899fd436d77de85