### PR TITLE
Ensure single active client for KVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ also retries the last known IP address. This means that whether the
 host or any receiver is powered on first, they will automatically find
 each other and connect once both sides are running.
 
-The desktop acting as the host now accepts multiple client connections simultaneously. All
-connected receivers will get the forwarded input events.
+The desktop acting as the host can accept multiple client connections at once. Only the
+selected receiver will get the forwarded input events. Switch targets with the hotkeys to
+transfer control exclusively.
 
 ### Host hotkeys
 


### PR DESCRIPTION
### **User description**
## Summary
- clarify in README that only one selected receiver gets input events
- automatically select a new active client when the current one disconnects
- avoid broadcasting events when no active client is set

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_6869121c1f8c8327b4df8409385130d3


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix active client selection when current client disconnects

- Automatically switch to next available client on disconnection

- Prevent broadcasting events when no active client selected

- Update README to clarify single active receiver behavior


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Client Disconnect"] --> B["Check Remaining Clients"]
  B --> C["Auto-select Next Client"]
  C --> D["Update Status Message"]
  E["KVM Activation"] --> F["Ensure Active Client Set"]
  F --> G["Send Events to Single Target"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker.py</strong><dd><code>Fix active client management logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker.py

<li>Auto-select next client when active client disconnects<br> <li> Ensure active client is set before KVM activation<br> <li> Send events only to active client, not all clients<br> <li> Add status messages for client switching


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/200/files#diff-ef0ecc97a9e678e23ad77ea341fd81fb27bb2e63608a6556074ca2225ae69330">+26/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update client behavior documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Clarify that only selected receiver gets input events<br> <li> Update documentation about multiple client behavior


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/200/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>