### PR TITLE
Improve file transfer stability and logging

### DIFF
--- a/file_transfer.py
+++ b/file_transfer.py
@@ -294,7 +294,7 @@ class FileTransferHandler:
                     )
                     if not self.worker._send_message(sock, {'type': 'file_chunk', 'data': chunk}):
                         logging.error(
-                            "Failed to send file chunk at offset %d for %s",
+                            "Failed to send file chunk at offset %d for %s. Aborting transfer.",
                             sent,
                             name,
                         )


### PR DESCRIPTION
### **User description**
## Summary
- keep existing socket timeout after sending KVM events so file transfer timeout isn't overwritten
- log socket timeout value when monitor thread hits a timeout
- log message type when send failure happens
- clarify file chunk failure message

## Testing
- `pycodestyle --max-line-length=120 worker.py file_transfer.py` *(fails: E722, W293, E303, E306, E231, E501, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6869129833e08327ae01f40dacc0d37b


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix socket timeout override preventing file transfers

- Enhance error logging with message types

- Improve timeout debugging information

- Clarify file transfer failure messages


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Socket timeout preservation"] --> B["File transfer stability"]
  C["Enhanced error logging"] --> D["Better debugging"]
  E["Message type logging"] --> D
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker.py</strong><dd><code>Fix timeout override and enhance logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker.py

<li>Preserve original socket timeout after KVM events<br> <li> Add message type to send failure error logs<br> <li> Log socket timeout value on monitor thread timeout


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/201/files#diff-ef0ecc97a9e678e23ad77ea341fd81fb27bb2e63608a6556074ca2225ae69330">+13/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file_transfer.py</strong><dd><code>Improve file transfer error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

file_transfer.py

- Clarify file chunk failure message with "Aborting transfer"


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/201/files#diff-518373b47a3ee594e57276192848e7a605aca7ace022adb0ba95fc9bade67eff">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>