### PR TITLE
Fix autostart path when running packaged build

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ packaged build this autostart setting is also honoured when the ``.exe`` is
 started manually, causing the window to stay in the tray and the previous
 connection to activate immediately.
 
+Every time the application starts it now refreshes the registry entry when
+autostart is enabled, so the path always refers to the currently running
+executable. This prevents console windows from appearing if the application was
+packaged after enabling autostart from a normal Python interpreter.
+
 
 ## Clipboard synchronization
 

--- a/gui.py
+++ b/gui.py
@@ -267,6 +267,13 @@ class MainWindow(QMainWindow):
         self.autostart_check.setChecked(
             settings.value("other/autostart", False, type=bool)
         )
+        # Ensure the autostart registry entry always references the
+        # currently running executable if the option is enabled.
+        if self.autostart_check.isChecked():
+            try:
+                set_autostart(True)
+            except Exception as e:
+                logging.error("Nem sikerült az autostart frissítése: %s", e)
         default_temp_path = QStandardPaths.writableLocation(QStandardPaths.TempLocation)
         self.temp_path_edit.setText(settings.value("other/temp_path", default_temp_path))
         self.temp_path_edit.textChanged.connect(self.save_settings)


### PR DESCRIPTION
## Summary
- refresh the Windows autostart registry entry during startup when autostart is enabled
- document this behaviour in README

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_686a48202ac48327ac1dd22b03929353