### PR TITLE
Fix connect_to_server delay and duplicate messages

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -1116,13 +1116,11 @@ class KVMWorker(QObject):
 
         retry_delay = 3
         max_retry_delay = 30
-        is_first_run = True
+
+        self.status_update.emit("Várakozás a hálózat inicializálására...")
+        time.sleep(5)
 
         while self._running:
-            if is_first_run:
-                self.status_update.emit("Waiting for network to initialize...")
-                time.sleep(5)
-                is_first_run = False
             ip = self.server_ip or self.last_server_ip
             if not ip:
                 time.sleep(0.5)
@@ -1135,7 +1133,6 @@ class KVMWorker(QObject):
                 ip,
                 self.file_handler._cancel_transfer.is_set(),
             )
-            self.status_update.emit(f"Connecting to server at {ip}...")
 
             try:
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:


### PR DESCRIPTION
### **User description**
## Summary
- ensure the network initialization delay only runs once
- drop English connection messages

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py worker.py` *(fails: E722, W293, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687b92708bac832782d2f1f2927eccf8


___

### **PR Type**
Bug fix


___

### **Description**
- Fix network initialization delay to run only once

- Remove duplicate connection status messages

- Replace English message with Hungarian localization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Network initialization"] --> B["Single delay execution"]
  C["Connection messages"] --> D["Remove duplicates"]
  E["English text"] --> F["Hungarian localization"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker.py</strong><dd><code>Fix connection delay and message handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker.py

<ul><li>Move network initialization delay outside the connection loop<br> <li> Remove <code>is_first_run</code> flag and related logic<br> <li> Replace English status message with Hungarian text<br> <li> Remove duplicate "Connecting to server" message</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/208/files#diff-ef0ecc97a9e678e23ad77ea341fd81fb27bb2e63608a6556074ca2225ae69330">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

