### PR TITLE
Add dynamic Raspberry Pico detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ When controlling the laptop, press **Ctrl + Shift + F12** to immediately switch
 control to the EliteDesk. The laptop client sends a command back to the host,
 which activates the EliteDesk as the new target.
 
+### Pico hardware buttons
+
+If a Raspberry Pi Pico is connected via USB, the application now monitors it
+with a dedicated background thread. Button `1` returns control to the desktop,
+`2` selects the laptop and `3` selects the EliteDesk. Connection and
+disconnection events are logged so you can verify detection in the console.
+
 ### Autostart
 
 On Windows the application configures autostart via the registry. When started

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ zeroconf
 monitorcontrol
 msgpack
 pyperclip
+pyserial


### PR DESCRIPTION
## Summary
- monitor Raspberry Pi Pico connection and button events
- start Pico serial thread in the worker and stop it cleanly
- require `pyserial`
- document hardware button usage in README

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py pico_serial_handler.py worker.py`

------
https://chatgpt.com/codex/tasks/task_e_687bd42060248327a7e0d926b967bc61