### PR TITLE
Add additional Pico VID detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,12 @@ which activates the EliteDesk as the new target.
 
 ### Pico hardware buttons
 
-If a Raspberry Pi Pico is connected via USB, the application now monitors it
-with a dedicated background thread. Button `1` returns control to the desktop,
-`2` selects the laptop and `3` selects the EliteDesk. Connection and
-disconnection events are logged so you can verify detection in the console.
+If a Raspberry Pi Pico or a compatible microcontroller is connected via USB,
+the application monitors it with a dedicated background thread. Boards using
+the Raspberry Pi VID ``0x2E8A`` or Adafruit's ``0x239A`` are detected
+automatically. Button `1` returns control to the desktop, `2` selects the laptop
+and `3` selects the EliteDesk. Connection and disconnection events are logged so
+you can verify detection in the console.
 
 ### Autostart
 

--- a/pico_serial_handler.py
+++ b/pico_serial_handler.py
@@ -11,16 +11,26 @@ class PicoSerialHandler:
     def _find_pico_port(self):
         """Return the device path of a connected Pico if available."""
         keywords = ("pico", "circuitpython")
+        candidates = []
         for port in list_ports.comports():
             try:
-                desc = port.description.lower()
+                desc = (port.description or "").lower()
                 manuf = (getattr(port, "manufacturer", "") or "").lower()
-                if port.vid == 0x2E8A:
+                vid = getattr(port, "vid", None)
+                if vid in (0x2E8A, 0x239A):
                     return port.device
                 if any(k in desc for k in keywords) or any(k in manuf for k in keywords):
                     return port.device
+                candidates.append((vid, desc, manuf))
             except Exception:
                 continue
+        for vid, desc, manuf in candidates:
+            logging.debug(
+                "Checked serial port VID=%s DESC='%s' MANUF='%s'",
+                f"0x{vid:04X}" if vid else "None",
+                desc,
+                manuf,
+            )
         return None
 
     def run(self):


### PR DESCRIPTION
## Summary
- detect Adafruit VID `0x239A` in Pico serial handler
- log candidate port info when no Pico is found
- document the new VID in the README

## Testing
- `python -m pycodestyle pico_serial_handler.py`
- `python -m py_compile pico_serial_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_687c018cfa508327b728a05afa6a5387