### PR TITLE
Add serial output to Pico HID script

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ with a dedicated background thread. Button `1` returns control to the desktop,
 `2` selects the laptop and `3` selects the EliteDesk. Connection and
 disconnection events are logged so you can verify detection in the console.
 
+### CircuitPython HID script
+
+The `pico_hid_switch.py` example runs directly on the Pico. It emulates the hotkey
+presses for switching computers and now opens the `usb_cdc` serial connection.
+When a button is pressed the script writes `b'1'`, `b'2'` or `b'3'` to the serial
+port and briefly pauses so the host receives the byte. The `PicoSerialHandler`
+in the desktop application listens for these values to activate the appropriate
+target.
+
 ### Autostart
 
 On Windows the application configures autostart via the registry. When started

--- a/pico_hid_switch.py
+++ b/pico_hid_switch.py
@@ -2,11 +2,14 @@ import time
 import board
 import digitalio
 import usb_hid
+import usb_cdc
 from adafruit_hid.keyboard import Keyboard
 from adafruit_hid.keycode import Keycode
 
 # Initialize the keyboard device
 kbd = Keyboard(usb_hid.devices)
+# Open the USB serial connection for sending button events
+serial = usb_cdc.data
 
 # Configure pins for the three buttons
 button1_pin = digitalio.DigitalInOut(board.GP16)
@@ -29,6 +32,9 @@ while True:
         kbd.press(Keycode.SHIFT, Keycode.KEYPAD_ZERO)
         time.sleep(0.1)
         kbd.release_all()
+        serial.write(b'1')
+        serial.flush()
+        time.sleep(0.05)
         while button1_pin.value:
             time.sleep(0.01)
 
@@ -37,6 +43,9 @@ while True:
         kbd.press(Keycode.SHIFT, Keycode.KEYPAD_ONE)
         time.sleep(0.1)
         kbd.release_all()
+        serial.write(b'2')
+        serial.flush()
+        time.sleep(0.05)
         while button2_pin.value:
             time.sleep(0.01)
 
@@ -45,6 +54,9 @@ while True:
         kbd.press(Keycode.SHIFT, Keycode.KEYPAD_TWO)
         time.sleep(0.1)
         kbd.release_all()
+        serial.write(b'3')
+        serial.flush()
+        time.sleep(0.05)
         while button3_pin.value:
             time.sleep(0.01)
 


### PR DESCRIPTION
## Summary
- open `usb_cdc.data` in `pico_hid_switch.py`
- send bytes `1`, `2`, `3` over serial when buttons are pressed
- document serial behavior in a new README section

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_687c019681108327bcd56c9fb96ddb3c