### PR TITLE
Update Pico boot config

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ with a dedicated background thread. Button `1` returns control to the desktop,
 `2` selects the laptop and `3` selects the EliteDesk. Connection and
 disconnection events are logged so you can verify detection in the console.
 
+After copying `boot.py` to the Pico you must reset the board for the new
+configuration to take effect.
+
 ### Autostart
 
 On Windows the application configures autostart via the registry. When started

--- a/boot.py
+++ b/boot.py
@@ -1,3 +1,5 @@
 import usb_hid
+import usb_cdc
 
 usb_hid.enable((usb_hid.Device.KEYBOARD,))
+usb_cdc.enable(console=True, data=True)


### PR DESCRIPTION
## Summary
- expand `boot.py` to enable `usb_cdc`
- document resetting the Pico after copying `boot.py`

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_687c019c74b88327bb9280b3eab985e8