### PR TITLE
Improve Pico port debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ The main dependencies are:
 
 After installing the dependencies, run `python main.py` to launch the GUI. The
 application logs activity to the console and stores settings via
-`QSettings`. Use the interface to configure host and client codes, select which
-computer this instance represents (Desktop, Laptop or EliteDesk) and start or
-stop the KVM service. The correct operating mode is selected automatically.
+`QSettings`. If you need to troubleshoot problems you can enable debug logging
+(see the section below) for much more detailed output. Use the interface to
+configure host and client codes, select which computer this instance represents
+(Desktop, Laptop or EliteDesk) and start or stop the KVM service. The correct
+operating mode is selected automatically.
 
 ### Automatic connection
 

--- a/pico_serial_handler.py
+++ b/pico_serial_handler.py
@@ -19,6 +19,13 @@ class PicoSerialHandler:
                     return port.device
                 if any(k in desc for k in keywords) or any(k in manuf for k in keywords):
                     return port.device
+                logging.debug(
+                    "Ignoring port device=%s vid=%s description=%s manufacturer=%s",
+                    port.device,
+                    port.vid,
+                    port.description,
+                    getattr(port, "manufacturer", ""),
+                )
             except Exception:
                 continue
         return None


### PR DESCRIPTION
## Summary
- log details of unmatched Pico serial ports at DEBUG level
- mention how to enable debug logging when running the app

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_687c01a0fdd883279a73c269c9f5f345