### PR TITLE
Improve Pico serial port detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ port and briefly pauses so the host receives the byte. The `PicoSerialHandler`
 in the desktop application listens for these values to activate the appropriate
 target.
 
+If both the console and data CDC interfaces are enabled, Windows will expose two
+COM ports. The application expects the **data** interface, so ensure this port is
+available or disable the console interface in `boot.py` to avoid connecting to
+the wrong one.
+
 After copying `boot.py` to the Pico you must reset the board for the new
 configuration to take effect.
 


### PR DESCRIPTION
## Summary
- prefer CDC data interface when selecting the Pico COM port
- document that Windows exposes two ports when both console and data are enabled

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_687c1d5cf58c8327bbd46a988f9b461e