### PR TITLE
Improve numpad hotkey handling

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -125,7 +125,8 @@ class MainWindow(QMainWindow):
         other_layout = QGridLayout()
         other_layout.addWidget(QLabel("Gyorsbillentyű:"), 0, 0)
         self.hotkey_label = QLabel(
-            "Asztal: Shift + Numpad 0 | Laptop: Shift + Numpad 1 | ElitDesk: Shift + Numpad 2"
+            "Asztal: Shift + Numpad 0 | Laptop: Shift + Numpad 1 | "
+            "ElitDesk: Shift + Numpad 2 (NumLock-tól független)"
         )
         other_layout.addWidget(self.hotkey_label, 0, 1)
         self.autostart_check = QCheckBox(


### PR DESCRIPTION
## Summary
- ensure host hotkeys only trigger from the numpad
- make hotkeys independent from NumLock state
- clarify NumLock behaviour in the GUI label

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687c1d97eb4c83279f17b076c37ce9f0