### PR TITLE
Fix clipboard sync read logic

### DIFF
--- a/clipboard_sync.py
+++ b/clipboard_sync.py
@@ -92,17 +92,25 @@ def send_clip(conn, text):
     conn.sendall(size + data)
 
 
-def recv_clip(conn):
-    size_data = conn.recv(4)
-    if not size_data:
-        return None
-    size = int.from_bytes(size_data, 'big')
+def _recv_exact(conn, size):
+    """Receive exactly ``size`` bytes from the connection or return ``None``."""
     data = b''
     while len(data) < size:
-        chunk = conn.recv(min(BUFFER_SIZE, size - len(data)))
+        chunk = conn.recv(size - len(data))
         if not chunk:
             return None
         data += chunk
+    return data
+
+
+def recv_clip(conn):
+    size_data = _recv_exact(conn, 4)
+    if not size_data:
+        return None
+    size = int.from_bytes(size_data, 'big')
+    data = _recv_exact(conn, size)
+    if data is None:
+        return None
     return data.decode('utf-8')
 
 


### PR DESCRIPTION
## Summary
- handle partial socket reads in clipboard sync tool

## Testing
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py`
- `python -m py_compile clipboard_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_6883cca5fa088327aca3f8a0fd17c8e5