### PR TITLE
Fix clipboard sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ The script relies on the `pyperclip` library for cross-platform clipboard access
 Install it with `pip install pyperclip`. On Linux, `pyperclip` also depends on
 either `xclip` or `xsel` (or `wl-clipboard` for Wayland) being available.
 Without these the script may not be able to read or write the clipboard.
+Only plain text clipboard contents are synchronized between computers; other
+clipboard formats are ignored to avoid interfering with local copy-paste
+operations.
 
 ## Formatting
 


### PR DESCRIPTION
## Summary
- ignore non-text clipboard content when syncing
- document that only text is synchronized

## Testing
- `python -m py_compile worker.py clipboard_sync.py file_transfer.py main.py gui.py boot.py build_exe.py pico_hid_switch.py pico_serial_handler.py pico_serial_test.py`
- `pycodestyle --max-line-length=120 gui.py clipboard_sync.py worker.py`

------
https://chatgpt.com/codex/tasks/task_e_6887bdcfed148327ac134a023579acfa