### PR TITLE
Add F16 hotkey to switch monitor input

### DIFF
--- a/config.py
+++ b/config.py
@@ -37,6 +37,7 @@ VK_END = 35
 VK_F13 = 124
 VK_F14 = 125
 VK_F15 = 126
+VK_F16 = 127
 
 
 def resource_path(relative_path: str) -> str:

--- a/pico_hid_switch.py
+++ b/pico_hid_switch.py
@@ -1,4 +1,4 @@
-# pico_hid_switch.py - VÉGLEGES HID VERZIÓ (F13-F15 billentyűkkel)
+# pico_hid_switch.py - VÉGLEGES HID VERZIÓ (F13-F16 billentyűkkel)
 
 import time
 import board
@@ -27,6 +27,11 @@ button2_pin.pull = digitalio.Pull.UP
 button3_pin = digitalio.DigitalInOut(board.GP15)
 button3_pin.direction = digitalio.Direction.INPUT
 button3_pin.pull = digitalio.Pull.UP
+
+# ÚJ GOMB: Gomb 4 (Monitor HDMI-1) -> F16 billentyűt küld
+button4_pin = digitalio.DigitalInOut(board.GP1)
+button4_pin.direction = digitalio.Direction.INPUT
+button4_pin.pull = digitalio.Pull.UP
 
 print("Pico KVM Remote (HID F-Key Mode) is running...")
 
@@ -59,6 +64,15 @@ while True:
         time.sleep(0.1)
         kbd.release_all()
         while not button3_pin.value:
+            time.sleep(0.01)
+
+    # 4. Gomb (GP1)
+    if not button4_pin.value:
+        print("Gomb 4 (GP1) lenyomva -> F16 küldése...")
+        kbd.press(Keycode.F16)
+        time.sleep(0.1)
+        kbd.release_all()
+        while not button4_pin.value:
             time.sleep(0.01)
 
     time.sleep(0.1)

--- a/worker.py
+++ b/worker.py
@@ -516,7 +516,7 @@ class KVMWorker(QObject):
         current_pressed_vk = set()
         numpad_pressed_vk = set()
         
-        VK_F13, VK_F14, VK_F15 = 124, 125, 126
+        VK_F13, VK_F14, VK_F15, VK_F16 = 124, 125, 126, 127
 
         def handle_action(action_name):
             logging.info(f"!!! Hotkey action triggered: {action_name} !!!")
@@ -539,6 +539,10 @@ class KVMWorker(QObject):
             if key == keyboard.Key.f15:
                 logging.info("!!! Pico gomb 3 (F15) észlelve !!!")
                 self.toggle_client_control('elitedesk', switch_monitor=True)
+                return
+            if key == keyboard.Key.f16:
+                logging.info("!!! Pico gomb 4 (F16) észlelve !!!")
+                self.switch_monitor_input(17)
                 return
 
             vk = getattr(key, 'vk', None)
@@ -563,7 +567,7 @@ class KVMWorker(QObject):
         hotkey_listener = keyboard.Listener(on_press=on_press, on_release=on_release)
         self.pynput_listeners.append(hotkey_listener)
         hotkey_listener.start()
-        logging.info("Pynput figyelő elindítva (kiterjesztve F13-F15 billentyűkkel).")
+        logging.info("Pynput figyelő elindítva (kiterjesztve F13-F16 billentyűkkel).")
         
     def _process_server_messages(self):
         """Process raw messages received from clients on the server."""


### PR DESCRIPTION
## Summary
- define VK_F16 virtual key code
- detect F16 press to switch monitor input
- extend Pico HID script with fourth button sending F16

## Testing
- `python -m py_compile config.py worker.py pico_hid_switch.py`
- `flake8 config.py worker.py pico_hid_switch.py` *(fails: line too long / unused imports and other style issues)*

------
https://chatgpt.com/codex/tasks/task_e_688f7cb106c88327b3a764e696732ae0