### PR TITLE
Refactor roles for centralized controller

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -118,9 +118,9 @@ class MainWindow(QMainWindow):
         role_layout = QHBoxLayout()
         role_layout.setSpacing(15)
         role_layout.setContentsMargins(10, 10, 10, 10)
-        self.radio_desktop = QRadioButton("Asztali gép (irányít)")
+        self.radio_desktop = QRadioButton("Asztali gép (Bemeneti forrás és kliens)")
         self.radio_laptop = QRadioButton("Laptop")
-        self.radio_elitedesk = QRadioButton("ElitDesk")
+        self.radio_elitedesk = QRadioButton("HP EliteDesk (Központi vezérlő)")
         role_layout.addWidget(self.radio_desktop)
         role_layout.addWidget(self.radio_laptop)
         role_layout.addWidget(self.radio_elitedesk)
@@ -204,17 +204,17 @@ class MainWindow(QMainWindow):
         self.load_settings()
 
     def get_settings(self):
-        if self.radio_desktop.isChecked():
-            mode = 'ado'
-            device = 'desktop'
-        elif self.radio_laptop.isChecked():
-            mode = 'vevo'
-            device = 'laptop'
-        else:
-            mode = 'vevo'
+        if self.radio_elitedesk.isChecked():
+            role = 'ado'
             device = 'elitedesk'
+        elif self.radio_desktop.isChecked():
+            role = 'input_provider'
+            device = 'desktop'
+        else:
+            role = 'vevo'
+            device = 'laptop'
         return {
-            'role': mode,
+            'role': role,
             'device_name': device,
             'port': int(self.port.text()),
             'monitor_codes': {


### PR DESCRIPTION
### **User description**
## Summary
- Clarify GUI role options and add new `input_provider` role
- Forward input events from desktop provider through EliteDesk server
- Introduce permanent input streaming for desktop provider without local suppression

## Testing
- `python -m py_compile gui.py worker.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'digitalio')*

------
https://chatgpt.com/codex/tasks/task_e_68c6ba8f7d008327bcc125e2d55526b1


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor GUI role options with clearer descriptions

- Add new `input_provider` role for desktop devices

- Implement permanent input streaming without local suppression

- Forward input events from desktop through EliteDesk server


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Desktop (Input Provider)"] -- "streams input events" --> B["EliteDesk (Central Controller)"]
  B -- "forwards events" --> C["Laptop (Receiver)"]
  B -- "manages switching" --> D["Monitor Control"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gui.py</strong><dd><code>Update GUI role options and settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui.py

<ul><li>Update radio button labels for clearer role descriptions<br> <li> Refactor settings logic to prioritize EliteDesk as central controller<br> <li> Change desktop role from 'ado' to 'input_provider'<br> <li> Reorganize role assignment logic flow</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/256/files#diff-3cbc0fcda69a9da6e615e2a4fe21b03f8ea6face1a58f166387467d0b0ac6762">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>worker.py</strong><dd><code>Implement centralized input forwarding architecture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker.py

<ul><li>Add input event forwarding logic for central controller role<br> <li> Implement <code>run_input_provider</code> method for desktop devices<br> <li> Create permanent input streaming without local suppression<br> <li> Disable streaming thread for 'ado' role devices<br> <li> Add comprehensive input event capture (mouse, keyboard, scroll)</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/256/files#diff-ef0ecc97a9e678e23ad77ea341fd81fb27bb2e63608a6556074ca2225ae69330">+83/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

