### PR TITLE
Ensure input provider uses correct central controller socket

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -269,6 +269,11 @@ class KVMWorker(QObject):
         except Exception:
             pass
         self.file_handler.on_client_disconnected(sock)
+        if sock == self.server_socket:
+            self.server_socket = None
+            logging.info(
+                "A központi vezérlővel való kapcsolat megszakadt, a server_socket törölve."
+            )
 
         with self.clients_lock:
             peer_name = self.client_infos.get(sock)
@@ -971,6 +976,11 @@ class KVMWorker(QObject):
             self.client_infos[sock] = client_name
             if self.active_client is None:
                 self.active_client = sock
+        if self.settings.get('role') == 'input_provider' and client_name == 'elitedesk':
+            self.server_socket = sock
+            logging.info(
+                f"Input provider sikeresen hozzárendelve a központi vezérlőhöz ({client_name})."
+            )
         if (
             self.pending_activation_target
             and self.pending_activation_target == client_name


### PR DESCRIPTION
## Summary
- Assign the connection to `elitedesk` as the `server_socket` when running in `input_provider` role
- Clear `server_socket` when the central controller disconnects

## Testing
- `python -m py_compile worker.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'usb_cdc')*
- `python -m pycodestyle worker.py` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c6bf452c488327ab7fee7f98ed8bf5