### PR TITLE
Refactor KVM control to target-based model

### DIFF
--- a/pico_serial_handler.py
+++ b/pico_serial_handler.py
@@ -73,11 +73,11 @@ class PicoSerialHandler:
                             continue
                         logging.info("Pico button pressed: %s", char)
                         if char == '1':
-                            self.worker.deactivate_kvm(switch_monitor=True, reason="pico button 1")
+                            self.worker.set_control_target('desktop')
                         elif char == '2':
-                            self.worker.toggle_client_control('laptop', switch_monitor=False)
+                            self.worker.set_control_target('laptop')
                         elif char == '3':
-                            self.worker.toggle_client_control('elitedesk', switch_monitor=True)
+                            self.worker.set_control_target('elitedesk')
                         elif char == '4':
                             logging.info("Pico button 4 pressed: Switching monitor input.")
                             self.worker.switch_monitor_input(17)


### PR DESCRIPTION
## Summary
- replace toggle-based client switching with new `set_control_target` helper
- forward or locally handle input events based on selected target
- map F13–F15 hotkeys and Pico buttons to `set_control_target`

## Testing
- `python -m py_compile worker.py pico_serial_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6cee4a9208327b9a93a369968b8a3