### PR TITLE
Refactor controller architecture for centralized EliteDesk flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ application logs activity to the console and stores settings via
 computer this instance represents (Desktop, Laptop or EliteDesk) and start or
 stop the KVM service. The correct operating mode is selected automatically.
 
+The software now follows a centralized control model. The EliteDesk runs the
+controller (`ado`) service and acts as the single decision point. The desktop
+machine is configured as an `input_provider` that forwards physical keyboard and
+mouse events only when instructed, while the laptop continues to operate as a
+simple `vevo` receiver. This keeps local control snappy and avoids sending
+unnecessary traffic across the network when you are working on the desktop
+itself.
+
 ### Automatic connection
 
 The receiver continuously searches for the host using Zeroconf and
@@ -69,20 +77,24 @@ each other and connect once both sides are running. If the connection
 is interrupted on either side, both peers keep searching and will
 reconnect automatically as soon as the other becomes available again.
 
-The desktop acting as the host can accept multiple client connections at once. Only the
-selected receiver will get the forwarded input events. Switch targets with the hotkeys to
-transfer control exclusively.
+The EliteDesk controller accepts connections from both the desktop input provider and any
+remote receivers. The desktop streams keyboard and mouse events only when the controller
+explicitly instructs it to do so, ensuring there is no unnecessary network traffic while
+you are working locally. When control is transferred to the EliteDesk the monitor input is
+switched to the secondary HDMI port, and it is switched back to HDMI1 as soon as you return
+to the desktop. Switching to the laptop never touches the monitor input.
 
-### Host hotkeys
+### Controller hotkeys
 
-While running on the desktop, use the following shortcuts to control the connected machines:
+While running on the EliteDesk controller you can switch targets either with the Pico
+hardware buttons (F13–F15) or by using the keyboard hotkeys:
 
-- **Shift + Numpad 1** – Take control of the laptop
-- **Shift + Numpad 2** – Take control of the EliteDesk and switch the monitor input
-- **Shift + Numpad 0** – Return control to the desktop and restore the monitor input
+- **Shift + Numpad 0 / F13** – Return control to the desktop input provider
+- **Shift + Numpad 1 / F14** – Route control to the laptop client (no monitor switch)
+- **Shift + Numpad 2 / F15** – Take control of the EliteDesk itself and switch the monitor to HDMI2
 
-Switching directly between the laptop and EliteDesk is disabled. Press `Shift + Numpad 0` first to
-return to the desktop before activating the other client.
+The controller always returns to the desktop before activating a different remote target so
+that the monitor state remains consistent.
 
 Slow clients that cannot keep up with the stream are disconnected after a short
 send timeout so they no longer cause lag for others. Input events are queued up

--- a/gui.py
+++ b/gui.py
@@ -118,9 +118,9 @@ class MainWindow(QMainWindow):
         role_layout = QHBoxLayout()
         role_layout.setSpacing(15)
         role_layout.setContentsMargins(10, 10, 10, 10)
-        self.radio_desktop = QRadioButton("Asztali gép (irányít)")
-        self.radio_laptop = QRadioButton("Laptop")
-        self.radio_elitedesk = QRadioButton("ElitDesk")
+        self.radio_desktop = QRadioButton("Asztali gép (bemeneti forrás)")
+        self.radio_laptop = QRadioButton("Laptop (kliens)")
+        self.radio_elitedesk = QRadioButton("EliteDesk (központi vezérlő)")
         role_layout.addWidget(self.radio_desktop)
         role_layout.addWidget(self.radio_laptop)
         role_layout.addWidget(self.radio_elitedesk)
@@ -150,8 +150,8 @@ class MainWindow(QMainWindow):
         other_layout = QGridLayout()
         other_layout.addWidget(QLabel("Gyorsbillentyű:"), 0, 0)
         self.hotkey_label = QLabel(
-            "Asztal: Shift + Numpad 0 | Laptop: Shift + Numpad 1 | "
-            "ElitDesk: Shift + Numpad 2 (NumLock-tól független)"
+            "Pico gombok: F13 → Asztali gép | F14 → Laptop | F15 → EliteDesk. "
+            "Billentyűzet: Shift + Num0 vissza asztalra, Shift + Num1 laptop, Shift + Num2 EliteDesk."
         )
         other_layout.addWidget(self.hotkey_label, 0, 1)
         self.autostart_check = QCheckBox(
@@ -204,15 +204,15 @@ class MainWindow(QMainWindow):
         self.load_settings()
 
     def get_settings(self):
-        if self.radio_desktop.isChecked():
+        if self.radio_elitedesk.isChecked():
             mode = 'ado'
+            device = 'elitedesk'
+        elif self.radio_desktop.isChecked():
+            mode = 'input_provider'
             device = 'desktop'
-        elif self.radio_laptop.isChecked():
-            mode = 'vevo'
-            device = 'laptop'
         else:
             mode = 'vevo'
-            device = 'elitedesk'
+            device = 'laptop'
         return {
             'role': mode,
             'device_name': device,
@@ -265,14 +265,16 @@ class MainWindow(QMainWindow):
 
     def save_settings(self):
         settings = QSettings(ORG_NAME, APP_NAME)
-        if self.radio_desktop.isChecked():
-            device = 'desktop'
-        elif self.radio_laptop.isChecked():
-            device = 'laptop'
-        else:
+        if self.radio_elitedesk.isChecked():
             device = 'elitedesk'
+            mode = 'ado'
+        elif self.radio_desktop.isChecked():
+            device = 'desktop'
+            mode = 'input_provider'
+        else:
+            device = 'laptop'
+            mode = 'vevo'
         settings.setValue("device/name", device)
-        mode = 'ado' if device == 'desktop' else 'vevo'
         settings.setValue("role/mode", mode)
         settings.setValue("network/port", self.port.text())
         settings.setValue("monitor/host_code", self.host_code.text())


### PR DESCRIPTION
## Summary
- introduce an explicit input_provider role and centralize control decisions on the EliteDesk
- add a dedicated input streaming loop for the desktop provider and route incoming events per active target on the controller
- refresh the GUI and documentation to reflect the new centralized architecture, Pico hotkeys and monitor switching rules

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c9691955ac8327bbe833c469d25f8a