### PR TITLE
Disable monitor switching when toggling between laptop and elitedesk

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -783,8 +783,15 @@ class KVMWorker(QObject):
                 return
             if self.kvm_active:
                 prior_was_elitedesk = self.current_target == 'elitedesk'
+                switching_between_main_targets = (
+                    self.current_target in {'laptop', 'elitedesk'}
+                    and target in {'laptop', 'elitedesk'}
+                    and self.current_target != target
+                )
+                if switching_between_main_targets:
+                    switch_monitor = False
                 self.deactivate_kvm(
-                    switch_monitor=prior_was_elitedesk,
+                    switch_monitor=False if switching_between_main_targets else prior_was_elitedesk,
                     release_keys=release_keys,
                     reason="controller switch",
                 )


### PR DESCRIPTION
### **User description**
## Summary
- avoid HDMI input changes when switching control between the EliteDesk and laptop clients
- ensure both deactivate and activate paths skip monitor switching for these toggles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9877fb9308327ac1bdc90ebdc8868


___

### **PR Type**
Enhancement


___

### **Description**
- Disable monitor switching when toggling between laptop and elitedesk

- Add logic to detect switching between main targets

- Prevent HDMI input changes during laptop/elitedesk toggles

- Modify deactivate_kvm call to skip monitor switching conditionally


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Toggle Request"] --> B["Check Main Targets"]
  B --> C["Laptop/EliteDesk Switch?"]
  C -->|Yes| D["Disable Monitor Switch"]
  C -->|No| E["Normal Monitor Switch"]
  D --> F["Deactivate KVM"]
  E --> F["Deactivate KVM"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker.py</strong><dd><code>Disable monitor switching for laptop/elitedesk toggles</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker.py

<ul><li>Add detection logic for switching between laptop and elitedesk targets<br> <li> Set <code>switch_monitor</code> to False when toggling between main targets<br> <li> Modify <code>deactivate_kvm</code> call to conditionally skip monitor switching<br> <li> Preserve existing behavior for other target combinations</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/266/files#diff-ef0ecc97a9e678e23ad77ea341fd81fb27bb2e63608a6556074ca2225ae69330">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

