### PR TITLE
Enable synchronization of mouse x1 button

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -214,6 +214,9 @@ class KVMWorker(QObject):
             'right': mouse.Button.right,
             'middle': mouse.Button.middle,
         }
+        extra_button = getattr(mouse.Button, 'x1', None)
+        if extra_button is not None:
+            button_map['x1'] = extra_button
         msg_type = data.get('type')
         if msg_type == 'move_relative':
             self.mouse_controller.move(data.get('dx', 0), data.get('dy', 0))
@@ -1112,6 +1115,9 @@ class KVMWorker(QObject):
             'right': mouse.Button.right,
             'middle': mouse.Button.middle,
         }
+        extra_button = getattr(mouse.Button, 'x1', None)
+        if extra_button is not None:
+            button_map['x1'] = extra_button
         while self._running:
             try:
                 sock, data = self.message_queue.get()


### PR DESCRIPTION
### **User description**
## Summary
- add support for the mouse side button (x1) when applying provider events locally
- ensure clients map the forwarded x1 button to the pynput controller

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c99617fddc8327b80fec9839306e48


___

### **PR Type**
Enhancement


___

### **Description**
- Add support for mouse x1 button synchronization

- Enable forwarding of x1 button events between clients

- Implement dynamic button mapping with fallback handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mouse x1 button event"] --> B["Dynamic button mapping"]
  B --> C["Event forwarding"]
  C --> D["Local application"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker.py</strong><dd><code>Add x1 button support to mouse synchronization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker.py

<ul><li>Add dynamic x1 button mapping using <code>getattr</code> with fallback<br> <li> Update button mapping in both <code>_apply_event_locally</code> and <br><code>_process_client_messages</code> methods<br> <li> Ensure x1 button events are properly forwarded and applied locally</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/268/files#diff-ef0ecc97a9e678e23ad77ea341fd81fb27bb2e63608a6556074ca2225ae69330">+14/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

