### PR TITLE
Ensure HDMI input switches back to host after laptop hop

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -1476,10 +1476,15 @@ class KVMWorker(QObject):
             if self.clipboard_thread and self.clipboard_thread.is_alive():
                 self.clipboard_thread.join(timeout=1)
                 self.clipboard_thread = None
+            host_code = self.settings['monitor_codes']['host']
+            need_switch = self.current_monitor_input != host_code
             do_switch = switch_monitor
             if do_switch is None:
-                do_switch = prev_target == 'elitedesk'
-            self._switch_monitor_for_target('desktop', allow_switch=bool(do_switch and prev_target == 'elitedesk'))
+                do_switch = prev_target == 'elitedesk' or need_switch
+            self._switch_monitor_for_target(
+                'desktop',
+                allow_switch=bool(do_switch and need_switch),
+            )
             self.status_update.emit("Állapot: Asztali gép irányít")
             if release_keys:
                 self.release_hotkey_keys()


### PR DESCRIPTION
### **User description**
## Summary
- update the controller deactivation logic to check the last monitor input and request a HDMI switch back to the host when needed
- avoid missing the HDMI1 fallback when returning to the desktop after visiting the laptop from the EliteDesk

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c9a35fba5c8327b1f31fa8ff732638


___

### **PR Type**
Bug fix


___

### **Description**
- Fix HDMI monitor switching logic when deactivating KVM

- Ensure monitor switches to host input after laptop usage

- Improve fallback behavior for EliteDesk to desktop transitions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["KVM Deactivation"] --> B["Check Current Monitor Input"]
  B --> C["Compare with Host Code"]
  C --> D["Determine Switch Need"]
  D --> E["Execute Monitor Switch"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker.py</strong><dd><code>Enhanced KVM deactivation monitor switching logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

worker.py

<ul><li>Add logic to check current monitor input against host code<br> <li> Modify switch condition to include input mismatch detection<br> <li> Update monitor switching parameters for better control</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/271/files#diff-ef0ecc97a9e678e23ad77ea341fd81fb27bb2e63608a6556074ca2225ae69330">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

