### PR TITLE
Add F17 hotkey to switch monitor to HDMI2

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ hardware buttons (F13–F15) or by using the keyboard hotkeys:
 - **Shift + Numpad 0 / F13** – Return control to the desktop input provider
 - **Shift + Numpad 1 / F14** – Route control to the laptop client (no monitor switch)
 - **Shift + Numpad 2 / F15** – Take control of the EliteDesk itself and switch the monitor to HDMI2
+- **F17** – Manually switch the primary monitor input to HDMI2 without changing the active client
 
 The controller always returns to the desktop before activating a different remote target so
 that the monitor state remains consistent.

--- a/worker.py
+++ b/worker.py
@@ -1015,6 +1015,10 @@ class KVMWorker(QObject):
                 logging.info("!!! Pico gomb 4 (F16) észlelve !!!")
                 self.switch_monitor_input(17)
                 return
+            if key == keyboard.Key.f17:
+                logging.info("!!! F17 gyorsbillentyű érzékelve – monitor váltás HDMI2-re !!!")
+                self.switch_monitor_input(18)
+                return
 
             vk = getattr(key, 'vk', None)
             if vk is None: return
@@ -1038,7 +1042,7 @@ class KVMWorker(QObject):
         hotkey_listener = keyboard.Listener(on_press=on_press, on_release=on_release)
         self.pynput_listeners.append(hotkey_listener)
         hotkey_listener.start()
-        logging.info("Pynput figyelő elindítva (kiterjesztve F13-F16 billentyűkkel).")
+        logging.info("Pynput figyelő elindítva (kiterjesztve F13-F17 billentyűkkel).")
         
     def _process_server_messages(self):
         """Process raw messages received from clients on the server."""


### PR DESCRIPTION
## Summary
- handle F17 presses in the global hotkey listener by switching the monitor input to HDMI2
- update the README to document the manual HDMI2 hotkey

## Testing
- python -m compileall worker.py

------
https://chatgpt.com/codex/tasks/task_e_68c9a3a4b94483279b5f2c4790da10ba