### PR TITLE
Keep GUI position when switching views

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -94,7 +94,7 @@ class MainWindow(QMainWindow):
         'start_button', 'status_label', 'kvm_thread', 'kvm_worker',
         'tray_icon', 'tray_hover_timer', '_tray_hover_visible',
         'stack', 'main_view', 'file_transfer_widget', 'file_transfer_button',
-        '_main_view_size', '_initial_show_done', '_file_transfer_centered'
+        '_main_view_size', '_initial_show_done'
     )
 
     # A MainWindow többi része változatlan...
@@ -104,7 +104,6 @@ class MainWindow(QMainWindow):
         self.setWindowIcon(QIcon(ICON_PATH))
         self._main_view_size = QSize(450, 560)
         self._initial_show_done = False
-        self._file_transfer_centered = False
 
         self.stack = QStackedWidget()
         self.setCentralWidget(self.stack)
@@ -195,19 +194,20 @@ class MainWindow(QMainWindow):
         return central_widget
 
     def show_file_transfer(self):
+        top_left = self.frameGeometry().topLeft()
         self.stack.setCurrentWidget(self.file_transfer_widget)
         self.setMinimumSize(QSize(900, 600))
         self.setMaximumSize(QSize(16777215, 16777215))
         self.resize(980, 680)
-        if not self._file_transfer_centered:
-            self._center_on_screen()
-            self._file_transfer_centered = True
+        self.move(top_left)
 
     def show_main_view(self):
+        top_left = self.frameGeometry().topLeft()
         self.stack.setCurrentWidget(self.main_view)
         self.setMinimumSize(self._main_view_size)
         self.setMaximumSize(self._main_view_size)
         self.resize(self._main_view_size)
+        self.move(top_left)
 
     def showEvent(self, event: QShowEvent) -> None:
         super().showEvent(event)


### PR DESCRIPTION
### **User description**
## Summary
- preserve the main window's top-left corner when toggling between the main view and the file transfer view to avoid unexpected jumps
- remove the unused `_file_transfer_centered` slot now that the window is no longer re-centered during the switch

## Testing
- python -m py_compile gui.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b8bae6648327b74172bf8d001e86


___

### **PR Type**
Bug fix


___

### **Description**
- Preserve window position when switching between views

- Remove unused centering logic and variable

- Fix unexpected window jumps during view transitions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Main View"] -- "preserve position" --> B["File Transfer View"]
  B -- "preserve position" --> A
  C["Remove centering logic"] --> D["Stable window position"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gui.py</strong><dd><code>Fix window position preservation during view switching</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui.py

<ul><li>Store window top-left position before switching views<br> <li> Apply stored position after view change to prevent jumps<br> <li> Remove unused <code>_file_transfer_centered</code> slot variable<br> <li> Remove automatic centering logic from view switching</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/278/files#diff-3cbc0fcda69a9da6e615e2a4fe21b03f8ea6face1a58f166387467d0b0ac6762">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

