### PR TITLE
Make discovery and connection resilient with retrying resolver and aggressive reconnects

### DIFF
--- a/kvm_core/orchestrator.py
+++ b/kvm_core/orchestrator.py
@@ -1039,6 +1039,15 @@ class KVMOrchestrator(QObject):
             role = self.settings.get('role')
             self._network_watchdog_stop.clear()
             if role == 'vevo':
+                register_ok = self._register_service()
+                self.peer_manager.start()
+                if self.clipboard_manager:
+                    self.clipboard_manager.start()
+                self._network_services_active = True
+                if not register_ok:
+                    logging.warning(
+                        "Zeroconf registration failed; running without service advertisement"
+                    )
                 self._network_watchdog_thread = threading.Thread(
                     target=self._network_watchdog_loop,
                     daemon=True,


### PR DESCRIPTION
### **User description**
### Motivation
- The service discovery dropped names on a single failed resolution which caused clients to permanently miss servers after startup races or dropped mDNS packets.  
- Connection manager only used a last-known-IP fallback and could avoid aggressive reconnect attempts to discovered peers.  
- The orchestrator did not always advertise services for all roles immediately, delaying mesh visibility and recovery after network changes.  
- The goal is to make discovery and peer connections persistent so peers auto-recover from startup races and transient network issues.  

### Description
- Implemented a retry queue in `kvm_core/network/discovery.py` by adding a `_pending` map, `_RETRY_INTERVAL`, and `_attempt_resolve` so names are retried periodically instead of being discarded.  
- Made resolver queue handling thread-safe using the existing `self._lock` and ensured pending entries are cleared on stop and on `remove_service`.  
- Updated `kvm_core/network/peer_manager.py` to iterate resolved peers aggressively and attempt `connect_to_peer` for any resolved-but-not-connected peer, treating `last_server_ip` as a fallback only when no discovery targets exist.  
- Made connection attempts tolerant of `ConnectionRefusedError` (logged and retried next cycle) and added defensive exception logging in the connection manager while keeping existing SSL/TLS wrapping in `connect_to_peer`.  
- Ensured `kvm_core/orchestrator.py` registers services for the `vevo` role on startup and starts peer services immediately so advertisement is continuous and watchdog-driven re-registration remains available.  

### Testing
- No automated tests were executed as part of this change.  
- Code compiled and basic import/commit operations succeeded in the development environment (no unit/integration test runs).  
- Recommend running the existing test suite and a network-startup race scenario to validate automatic recovery behavior.  
- Recommend monitoring logs for resolver retry messages and connection retry handling during integration testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956833ae34083278088c953aa85efb3)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implemented retry queue mechanism for failed service resolutions
  - Added `_pending` map to track unresolved services with retry timing
  - Periodically retries failed resolutions instead of discarding them

- Made peer connection attempts resilient to transient failures
  - Catches and logs `ConnectionRefusedError` separately for retry handling
  - Treats `last_server_ip` fallback only when no discovery targets exist

- Ensured immediate service advertisement on startup
  - Registers `vevo` role services before starting peer manager
  - Enables continuous watchdog-driven re-registration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Service Discovery"] -->|"Retry failed resolutions"| B["Pending Queue with Timing"]
  B -->|"Periodic retry attempts"| C["_attempt_resolve Method"]
  C -->|"Success/Failure"| D["Peers Dictionary"]
  E["Peer Manager"] -->|"Iterate discovered peers"| F["Connection Attempts"]
  F -->|"Handle ConnectionRefusedError"| G["Retry Next Cycle"]
  H["Orchestrator Startup"] -->|"Register services immediately"| I["Service Advertisement"]
  I -->|"Watchdog re-registration"| J["Persistent Availability"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>discovery.py</strong><dd><code>Add retry queue for persistent service resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kvm_core/network/discovery.py

<ul><li>Added <code>_RETRY_INTERVAL</code> constant (2.5 seconds) for retry scheduling<br> <li> Introduced <code>_pending</code> dictionary to track unresolved services with <br>attempt counts and next retry times<br> <li> Refactored <code>_resolver_loop</code> to check pending entries against current <br>time and retry due items<br> <li> Extracted resolution logic into new <code>_attempt_resolve</code> method returning <br>success/failure boolean<br> <li> Clear pending entries on service stop and removal</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/438/files#diff-ccf1b4db23a1413ad1445733f6fdba1617f01da61d013b182e1bcfc5370eb55b">+67/-26</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>peer_manager.py</strong><dd><code>Add resilient connection retry with error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kvm_core/network/peer_manager.py

<ul><li>Modified <code>last_server_ip</code> fallback to only activate when no discovery <br>targets exist<br> <li> Added try-catch block around <code>connect_to_peer</code> calls to handle <br><code>ConnectionRefusedError</code> separately<br> <li> Log <code>ConnectionRefusedError</code> at info level for transient failures<br> <li> Log other exceptions at debug level for connection manager errors<br> <li> Added exception handling in <code>connect_to_peer</code> to catch and log <br><code>ConnectionRefusedError</code> with proper socket cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/438/files#diff-64af43818f86efbc0a663e945ca0118eebbc6f57eb483862963389ae72976dda">+29/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>orchestrator.py</strong><dd><code>Register services immediately on startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kvm_core/orchestrator.py

<ul><li>Call <code>_register_service()</code> immediately on startup for <code>vevo</code> role before <br>starting peer manager<br> <li> Start peer manager and clipboard manager immediately after <br>registration<br> <li> Set <code>_network_services_active</code> flag to indicate active service <br>advertisement<br> <li> Log warning if initial Zeroconf registration fails but continue <br>operation</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/438/files#diff-96209c6755bcac56b2c0c304640a8f667aaa0a6cae75bac5d597d2d8c90d15f8">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

