### PR TITLE
Add direct F22 routing to input provider (global hotkey bypass)

### DIFF
--- a/hardware/button_input_manager.py
+++ b/hardware/button_input_manager.py
@@ -90,7 +90,7 @@ class ButtonInputManager:
             Key.f16: lambda: self._handle_hdmi1("keyboard F16"),
             Key.f17: lambda: self._handle_hdmi2("keyboard F17"),
             Key.f21: lambda: self._handle_monitor_toggle("keyboard F21"),
-            Key.f22: lambda: self._forward_or_emit_host_key(Key.f22, "keyboard F22"),
+            Key.f22: lambda: self._force_send_f22("keyboard F22"),
         }
         self._serial_action_map = {
             "KEY_Asztal": lambda: self._handle_asztal("pico KEY_Asztal"),
@@ -102,7 +102,7 @@ class ButtonInputManager:
             "KEY_Hang_1": lambda: self._forward_or_emit_host_key(Key.f18, "pico KEY_Hang_1"),
             "KEY_Hang_2": lambda: self._forward_or_emit_host_key(Key.f19, "pico KEY_Hang_2"),
             "KEY_Hang_3": lambda: self._forward_or_emit_host_key(Key.f20, "pico KEY_Hang_3"),
-            "KEY_Nemitas": lambda: self._forward_or_emit_host_key(Key.f22, "pico KEY_Nemitas"),
+            "KEY_Nemitas": lambda: self._force_send_f22("pico KEY_Nemitas"),
             # Legacy numeric protocol compatibility
             "1": lambda: self._handle_asztal("pico legacy 1"),
             "2": lambda: self._handle_laptop("pico legacy 2"),
@@ -169,6 +169,14 @@ class ButtonInputManager:
     def _handle_monitor_toggle(self, source: str) -> None:
         logging.info("Monitor power toggle requested by %s", source)
         self.worker.toggle_monitor_power()
+
+    def _force_send_f22(self, source: str) -> None:
+        logging.info("Direct F22 trigger requested by %s", source)
+        try:
+            if self.worker.force_send_f22_to_desktop():
+                return
+        except AttributeError:
+            logging.warning("Worker does not support direct F22 trigger")
 
     def _forward_or_emit_host_key(self, key: Key, source: str) -> None:
         """Try forwarding the key press to the desktop provider, fall back locally."""

--- a/kvm_core/message_handler.py
+++ b/kvm_core/message_handler.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from datetime import date
 from typing import Any, Callable, Dict, Optional
+
+from pynput import keyboard
 
 from kvm_core.clipboard import ClipboardManager
 from kvm_core.input.receiver import InputReceiver
@@ -168,6 +171,11 @@ class MessageHandler:
                     return
                 if cmd == 'stop_stream':
                     self._stop_input_provider_stream()
+                    return
+                if cmd == 'force_f22_trigger':
+                    self._input_receiver.keyboard_controller.press(keyboard.Key.f22)
+                    time.sleep(0.05)
+                    self._input_receiver.keyboard_controller.release(keyboard.Key.f22)
                     return
                 if cmd == 'host_key_tap':
                     key_type = data.get('key_type', 'vk')

--- a/kvm_core/network/peer_manager.py
+++ b/kvm_core/network/peer_manager.py
@@ -276,6 +276,13 @@ class PeerManager:
             return False
         return connection.send(message)
 
+    def get_socket_by_role(self, target_role: str) -> Optional[socket.socket]:
+        client_roles = self._state.get_client_roles()
+        for sock, role in client_roles.items():
+            if role == target_role:
+                return sock
+        return None
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/kvm_core/orchestrator.py
+++ b/kvm_core/orchestrator.py
@@ -432,6 +432,18 @@ class KVMOrchestrator(QObject):
             return False
         return self.peer_manager.send_to_peer(sock, payload)
 
+    def force_send_f22_to_desktop(self) -> bool:
+        """Send a direct F22 trigger to the input provider, bypassing routing."""
+        sock = self.peer_manager.get_socket_by_role("input_provider")
+        if not sock:
+            logging.warning("Input provider is not connected; cannot force F22 trigger")
+            return False
+        payload = {"command": "force_f22_trigger"}
+        if not self.peer_manager.send_to_peer(sock, payload):
+            logging.warning("Failed to send force F22 trigger to input provider")
+            return False
+        return True
+
     def _send_to_server(self, payload: dict) -> bool:
         if self.settings.get('role') == 'ado':
             return False


### PR DESCRIPTION
### **User description**
### Motivation

- Ensure a physical Pico button mapped to F22 on the server is always delivered to the Desktop (`input_provider`) regardless of the KVM active target or state.  
- Provide a direct messaging path that bypasses the regular KVM routing/state machine for this specific global hotkey.  

### Description

- Added `get_socket_by_role` in `kvm_core/network/peer_manager.py` to look up a peer socket by role.  
- Added `force_send_f22_to_desktop` in `kvm_core/orchestrator.py` to locate the `input_provider` socket and send a `{'command': 'force_f22_trigger'}` payload.  
- Updated `hardware/button_input_manager.py` to route `Key.f22` and the Pico `KEY_Nemitas` event to the new direct send path by calling the orchestrator via `self.worker.force_send_f22_to_desktop()`.  
- Added a handler for `force_f22_trigger` in `kvm_core/message_handler.py` that simulates an F22 press/release using `self._input_receiver.keyboard_controller`.  

### Testing

- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a405223483279fa2b8dde6f38b92)


___

### **PR Type**
Enhancement


___

### **Description**
- Add direct F22 routing to input provider bypassing KVM state machine

- Implement `get_socket_by_role` method for peer socket lookup by role

- Add `force_send_f22_to_desktop` orchestrator method for direct F22 delivery

- Handle `force_f22_trigger` command in message handler with keyboard simulation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Button Input Manager"] -->|"_force_send_f22"| B["Orchestrator"]
  B -->|"force_send_f22_to_desktop"| C["Peer Manager"]
  C -->|"get_socket_by_role"| D["Input Provider Socket"]
  D -->|"force_f22_trigger command"| E["Message Handler"]
  E -->|"keyboard simulation"| F["Desktop Input"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>button_input_manager.py</strong><dd><code>Route F22 events through direct send method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hardware/button_input_manager.py

<ul><li>Replace <code>_forward_or_emit_host_key</code> with new <code>_force_send_f22</code> method for <br>F22 and KEY_Nemitas events<br> <li> Add <code>_force_send_f22</code> method that calls <br><code>worker.force_send_f22_to_desktop()</code> with error handling<br> <li> Log direct F22 trigger requests and handle AttributeError gracefully</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/443/files#diff-7cb81f9cca29b973d82919f05c261bd6d4501a52d5ce3bf9f2528439032cf25c">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>peer_manager.py</strong><dd><code>Add socket lookup by peer role method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kvm_core/network/peer_manager.py

<ul><li>Add <code>get_socket_by_role</code> method to lookup peer socket by target role<br> <li> Iterate through client roles to find matching socket for given role<br> <li> Return socket if found, otherwise return None</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/443/files#diff-64af43818f86efbc0a663e945ca0118eebbc6f57eb483862963389ae72976dda">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>orchestrator.py</strong><dd><code>Add direct F22 trigger orchestrator method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kvm_core/orchestrator.py

<ul><li>Add <code>force_send_f22_to_desktop</code> method for direct F22 delivery to input <br>provider<br> <li> Use <code>peer_manager.get_socket_by_role</code> to locate input provider socket<br> <li> Send <code>force_f22_trigger</code> command payload with logging for failures</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/443/files#diff-96209c6755bcac56b2c0c304640a8f667aaa0a6cae75bac5d597d2d8c90d15f8">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>message_handler.py</strong><dd><code>Handle force F22 trigger command with simulation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kvm_core/message_handler.py

<ul><li>Import <code>time</code> module and <code>keyboard</code> from pynput for keyboard simulation<br> <li> Add handler for <code>force_f22_trigger</code> command in input provider message <br>processing<br> <li> Simulate F22 key press and release with 50ms delay between press and <br>release</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/Szamitepvalto-Extravaganza/pull/443/files#diff-af1f89e01c73faa0b1f2faede23834511a08d1462d16ad21f8e3cdaa6bb79feb">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

