### PR TITLE
Auto-heal stale input_provider socket and ignore closed sockets for F22 trigger

### DIFF
--- a/kvm_core/message_handler.py
+++ b/kvm_core/message_handler.py
@@ -35,6 +35,7 @@ class MessageHandler:
         stop_input_provider_stream: Callable[[], None],
         simulate_provider_key_tap: Callable[..., None],
         get_input_provider_socket: Callable[[], Any],
+        set_input_provider_socket: Callable[[Any], None],
         state: KVMState,
         send_to_server: Callable[[dict], bool],
         get_device_name: Callable[[], str],
@@ -50,6 +51,7 @@ class MessageHandler:
         self._stop_input_provider_stream = stop_input_provider_stream
         self._simulate_provider_key_tap = simulate_provider_key_tap
         self._get_input_provider_socket = get_input_provider_socket
+        self._set_input_provider_socket = set_input_provider_socket
         self._state = state
         self._send_to_server = send_to_server
         self._get_device_name = get_device_name
@@ -151,8 +153,9 @@ class MessageHandler:
                         return
                     client_roles = self._state.get_client_roles()
                     if client_roles.get(peer_socket) == 'input_provider':
-                        logging.warning(
-                            "Input provider socket mismatch; routing event from %s",
+                        self._set_input_provider_socket(peer_socket)
+                        logging.info(
+                            "Auto-healed input provider socket for %s",
                             self._state.get_client_name(peer_socket, peer_socket),
                         )
                         self._handle_provider_event(data)

--- a/kvm_core/network/peer_manager.py
+++ b/kvm_core/network/peer_manager.py
@@ -279,7 +279,7 @@ class PeerManager:
     def get_socket_by_role(self, target_role: str) -> Optional[socket.socket]:
         client_roles = self._state.get_client_roles()
         for sock, role in client_roles.items():
-            if role == target_role:
+            if role == target_role and sock.fileno() != -1:
                 return sock
         return None
 

--- a/kvm_core/orchestrator.py
+++ b/kvm_core/orchestrator.py
@@ -183,6 +183,9 @@ class KVMOrchestrator(QObject):
         else:
             logging.info("Shared clipboard sync is temporarily disabled.")
 
+        def _update_input_provider_socket(sock) -> None:
+            self.input_provider_socket = sock
+
         self.message_handler = MessageHandler(
             get_role=lambda: self.settings.get('role'),
             toggle_client_control=self.toggle_client_control,
@@ -193,6 +196,7 @@ class KVMOrchestrator(QObject):
             stop_input_provider_stream=self._stop_input_provider_stream,
             simulate_provider_key_tap=self._simulate_provider_key_tap,
             get_input_provider_socket=lambda: self.input_provider_socket,
+            set_input_provider_socket=_update_input_provider_socket,
             state=self.state,
             send_to_server=self._send_to_server,
             get_device_name=lambda: self.device_name,
@@ -439,6 +443,7 @@ class KVMOrchestrator(QObject):
             logging.warning("Input provider is not connected; cannot force F22 trigger")
             return False
         payload = {"command": "force_f22_trigger"}
+        logging.info("Sending force F22 trigger to input provider")
         if not self.peer_manager.send_to_peer(sock, payload):
             logging.warning("Failed to send force F22 trigger to input provider")
             return False


### PR DESCRIPTION
### Motivation
- The orchestrator kept a stale `input_provider_socket` after desktop reconnects, causing repeated "Input provider socket mismatch" warnings and unreliable F22 hotkey triggers.
- The `MessageHandler` could not update the orchestrator's socket reference when it observed events from a new socket object even if that peer's role was `input_provider`.
- `PeerManager.get_socket_by_role` could return closed sockets, which prevented direct F22 triggers from reaching the live input provider.

### Description
- Added a `set_input_provider_socket` callback argument to `MessageHandler.__init__` and stored it as `self._set_input_provider_socket` for use by the handler.
- Implemented auto-heal logic in `MessageHandler.handle` so that when a provider-role validated event arrives from a different socket the handler calls `self._set_input_provider_socket(peer_socket)` and logs an info message instead of the old warning.
- Updated `PeerManager.get_socket_by_role` to skip closed sockets by checking `sock.fileno() != -1` before returning a socket.
- Exposed an `_update_input_provider_socket` helper in `KVMOrchestrator.__init__`, passed it to `MessageHandler` as `set_input_provider_socket`, and added an info log in `force_send_f22_to_desktop` when sending the F22 trigger.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a6129eec8327b8a33f08155d5fa3)